### PR TITLE
Improve MPRIS Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,7 +1341,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "image",
- "libmpv",
+ "libmpv2",
  "ratatui",
  "ratatui-image",
  "reqwest",
@@ -1368,15 +1368,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
-name = "libmpv"
-version = "2.0.1"
+name = "libmpv2"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7befa1412ea58aeed5f36da1ad795f15bc6aefd554455f5134f1d4f7b6522e7f"
 dependencies = [
- "libmpv-sys",
+ "libmpv2-sys",
 ]
 
 [[package]]
-name = "libmpv-sys"
-version = "3.1.0"
+name = "libmpv2-sys"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42124ba90561beede41d5e6ef64eef63fc1395cf83217e3dd1157294f7dcdb56"
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 crossbeam = "0.8.4"
 serde_yaml = "0.9.34"
-libmpv = { path = "./libmpv-rs" }
+libmpv2 = { version = "4" }
 ratatui = "0.29.0"
 crossterm = "0.28.1"
 ratatui-image = { version = "3.0.0", default-features = false, features = ["crossterm"] }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -291,12 +291,18 @@ impl App {
             KeyCode::Char('q') => self.exit(),
             // Seek backward
             KeyCode::Left | KeyCode::Char('r')  => {
+                let secs = f64::max(0.0, self.current_playback_state.duration * self.current_playback_state.percentage / 100.0 - 5.0);
+                self.update_mpris_position(secs);
+
                 if let Ok(mpv) = self.mpv_state.lock() {
                     let _ = mpv.mpv.command("seek", &["-5.0"]);
                 }
             }
             // Seek forward
             KeyCode::Right | KeyCode::Char('s') => {
+                let secs = self.current_playback_state.duration * self.current_playback_state.percentage / 100.0 + 5.0;
+                self.update_mpris_position(secs);
+
                 if let Ok(mpv) = self.mpv_state.lock() {
                     let _ = mpv.mpv.command("seek", &["5.0"]);
                 }
@@ -313,6 +319,7 @@ impl App {
                         let _ = mpv.mpv.command("playlist_next", &["force"]);
                     }
                 }
+                self.update_mpris_position(0.0);
             }
             // Next track
             KeyCode::Char('N') => {
@@ -324,6 +331,7 @@ impl App {
                     }
                     let _ = mpv.mpv.command("playlist_prev", &["force"]);
                 }
+                self.update_mpris_position(0.0);
             }
             // Play/Pause
             KeyCode::Char(' ') => {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -292,13 +292,13 @@ impl App {
             // Seek backward
             KeyCode::Left | KeyCode::Char('r')  => {
                 if let Ok(mpv) = self.mpv_state.lock() {
-                    let _ = mpv.mpv.seek_backward(5.0);
+                    let _ = mpv.mpv.command("seek", &["-5.0"]);
                 }
             }
             // Seek forward
             KeyCode::Right | KeyCode::Char('s') => {
                 if let Ok(mpv) = self.mpv_state.lock() {
-                    let _ = mpv.mpv.seek_forward(5.0);
+                    let _ = mpv.mpv.command("seek", &["5.0"]);
                 }
             }
             // Previous track
@@ -310,7 +310,7 @@ impl App {
                         (self.current_playback_state.duration * self.current_playback_state.percentage * 100000.0) as u64,
                     ).await;
                     if let Ok(mpv) = self.mpv_state.lock() {
-                        let _ = mpv.mpv.playlist_next_force();
+                        let _ = mpv.mpv.command("playlist_next", &["force"]);
                     }
                 }
             }
@@ -319,20 +319,20 @@ impl App {
                 if let Ok(mpv) = self.mpv_state.lock() {
                     let current_time = self.current_playback_state.duration * self.current_playback_state.percentage / 100.0;
                     if current_time > 5.0 {
-                        let _ = mpv.mpv.seek_absolute(0.0);
+                        let _ = mpv.mpv.command("seek", &["0.0", "absolute"]);
                         return;
                     }
-                    let _ = mpv.mpv.playlist_previous_force();
+                    let _ = mpv.mpv.command("playlist_prev", &["force"]);
                 }
             }
             // Play/Pause
             KeyCode::Char(' ') => {
                 if let Ok(mpv) = self.mpv_state.lock() {
                     if self.paused {
-                        let _ = mpv.mpv.unpause();
+                        let _ = mpv.mpv.set_property("pause", false);
                         self.paused = false;
                     } else {
-                        let _ = mpv.mpv.pause();
+                        let _ = mpv.mpv.set_property("pause", true);
                         self.paused = true;
                     }
                 }
@@ -683,8 +683,8 @@ impl App {
                                 
                                 if time != 0.0 {
                                     if let Ok(mpv) = self.mpv_state.lock() {
-                                        let _ = mpv.mpv.seek_absolute(time);
-                                        let _ = mpv.mpv.unpause();
+                                        let _ = mpv.mpv.command("seek", &[&time.to_string(), "absolute"]);
+                                        let _ = mpv.mpv.set_property("pause", false);
                                         self.paused = false;
                                         self.buffering = 1;
                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::env;
 // use serde_yaml::Value;
 // use std::{collections::HashMap};
 
-use libmpv::{*};
+use libmpv2::{*};
 
 use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -53,9 +53,9 @@ impl App {
                 MediaControlEvent::Toggle => {
                     self.paused = mpv.mpv.get_property("pause").unwrap_or(false);
                     if self.paused {
-                        let _ = mpv.mpv.unpause();
+                        let _ = mpv.mpv.set_property("pause", false);
                     } else {
-                        let _ = mpv.mpv.pause();
+                        let _ = mpv.mpv.set_property("pause", true);
                     }
                     self.paused = !self.paused;
                 }
@@ -66,25 +66,24 @@ impl App {
                         // position ticks
                         (self.current_playback_state.duration * self.current_playback_state.percentage * 100000.0) as u64,
                     );
-                    let _ = mpv.mpv.playlist_next_force();
+                    let _ = mpv.mpv.command("playlist_next", &["force"]);
                 }
                 MediaControlEvent::Previous => {
                     let current_time = self.current_playback_state.duration * self.current_playback_state.percentage / 100.0;
                     if current_time > 5.0 {
-                        let _ = mpv.mpv.seek_absolute(0.0);
+                        let _ = mpv.mpv.command("seek", &["0.0", "absolute"]);
                     } else {
-                        let _ = mpv.mpv.playlist_previous_force();
+                        let _ = mpv.mpv.command("playlist_prev", &["force"]);
                     }
                 }
                 MediaControlEvent::Stop => {
-                    // let _ = mpv.mpv.stop();
+                    let _ = mpv.mpv.command("stop", &["keep-playlist"]);
                 }
                 MediaControlEvent::Play => {
-                    let _ = mpv.mpv.unpause();
+                    let _ = mpv.mpv.set_property("pause", false);
                 }
                 MediaControlEvent::Pause => {
-                    let _ = mpv.mpv.pause();
-                }
+                    let _ = mpv.mpv.set_property("pause", true);
                 _ => {}
             }
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -123,6 +123,9 @@ pub struct App {
     mpv_thread: Option<thread::JoinHandle<()>>,
     pub mpv_state: Arc<Mutex<MpvState>>, // shared mutex for controlling mpv
 
+    pub mpris_paused: bool,
+    pub mpris_active_song_id: String,
+
     // every second, we get the playback state from the mpv thread
     sender: Sender<MpvPlaybackState>,
     receiver: Receiver<MpvPlaybackState>,
@@ -204,6 +207,8 @@ impl Default for App {
             selected_search_track: ListState::default(),
             client: None,
             mpv_thread: None,
+            mpris_paused: true,
+            mpris_active_song_id: String::from(""),
             mpv_state: Arc::new(Mutex::new(MpvState::new())),
             sender,
             receiver,


### PR DESCRIPTION
This PR addresses the readme section "Work is needed here" under MPRIS.

Thanks for creating this terminal client for Jellyfin :)
I'm in the process of switching over from `mopidy-jellyfin` and looked into improving the current MPRIS integration of jellyfin-tui.

This PR adds the following MPRIS controls:
* ✅ Play/Pause with feedback
* ✅ Next / Previous song
* ✅ Stop
* ✅ Seeking
* ✅ Improved tick mechanism resulting in reduced CPU and network usage (by networked media control connections such as KDE Connect)

As far as I can tell, the only major MPRIS feature missing now is album art.

ℹ️ This PR also updates the libmpv API call syntax to libmpv2 v4, removing the need to vendor (embed) libmpv in the git repo. Let me know if this change is desired.

Also do note that this is my first contribution on a Rust project, so do correct my style if anything looks off :)