### PR TITLE
fix: mpris cover art not updating on song change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jellyfin-tui"
-version = "1.0.5"
+version = "1.0.6-dev"
 dependencies = [
  "chrono",
  "color-thief",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jellyfin-tui"
-version = "1.0.5"
+version = "1.0.6-dev"
 edition = "2021"
 
 [dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -689,14 +689,28 @@ impl Client {
             }
         };
 
-        std::fs::create_dir_all(cache_dir.join("jellyfin-tui"))?;
-        std::fs::create_dir_all(cache_dir.join("jellyfin-tui").join("covers"))?;
+        if !cache_dir.join("jellyfin-tui").exists() {
+            std::fs::create_dir_all(cache_dir.join("jellyfin-tui"))?;
+            std::fs::create_dir_all(cache_dir.join("jellyfin-tui").join("covers"))?;
+        } else {
+            // TODO: maybe cache these images?
+            let files = std::fs::read_dir(cache_dir.join("jellyfin-tui").join("covers"))?;
+            for file in files {
+                let file = file?;
+                std::fs::remove_file(file.path())?;
+            }
+        }
 
-        let mut file = std::fs::File::create(cache_dir.join("jellyfin-tui").join("covers").join("cover.".to_string() + extension))?;
+        let mut file = std::fs::File::create(
+            cache_dir
+            .join("jellyfin-tui")
+            .join("covers")
+            .join(album_id.to_string() + "." + extension)
+        )?;
         let mut content =  Cursor::new(response.bytes().await?);
         std::io::copy(&mut content, &mut file)?;
 
-        Ok("cover.".to_string() + extension)
+        Ok(album_id.to_string() + "." + extension)
     }
 
     /// Produces URL of a song from its ID


### PR DESCRIPTION
- cover art file:// url was not unique and so didn't trigger an update for gnome and others