### PR TITLE
Update README.md to include Nix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Jellyfin-tui uses libmpv as the backend for audio playback. You need to have mpv
 paru -S jellyfin-tui
 ```
 
+#### Nix
+[jellyfin-tui](https://search.nixos.org/packages?channel=unstable&show=jellyfin-tui&from=0&size=50&sort=relevance&type=packages&query=jellyfin-tui) is available as a package in [Nixpkgs](https://search.nixos.org/packages).
+
 #### Other Linux
 Linux is the main target OS for this project. You can install mpv from your package manager.
 ```bash


### PR DESCRIPTION
I made a Nix package for jellyfin-tui, including it here. I didn't leave an example of how to install it because there's multiple different methods and the page linked already shows them, lmk if you want me to include one though. The package is one release behind atm but should update automatically once Nixpkg's periodic update scripts are run since I configured the update script in the package, to my understanding (and I did test and confirm that the update script works).