### PR TITLE
feat: offline mode / media downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +263,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
@@ -436,6 +451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,12 +506,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -570,6 +615,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,7 +643,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -629,10 +687,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "either"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -678,6 +745,17 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -753,6 +831,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -802,6 +892,28 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
 
 [[package]]
 name = "futures-io"
@@ -947,6 +1059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1090,33 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -1353,7 +1501,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jellyfin-tui"
-version = "1.1.3"
+version = "2.0.0-dev"
 dependencies = [
  "chrono",
  "color-thief",
@@ -1369,6 +1517,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "souvlaki",
+ "sqlx",
  "tokio",
 ]
 
@@ -1383,10 +1532,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libmpv2"
@@ -1411,6 +1575,17 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1463,6 +1638,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1547,12 +1732,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1675,6 +1898,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1933,27 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.3.0",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -2020,6 +2273,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,6 +2494,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,6 +2541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2570,9 @@ name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2317,6 +2614,209 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
+dependencies = [
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 5.4.0",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-sqlite",
+ "syn 2.0.98",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.8.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.11",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.8.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.11",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2827,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2490,6 +3001,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +3061,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2601,6 +3138,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2650,10 +3188,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2762,6 +3321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +3418,16 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jellyfin-tui"
-version = "1.1.3"
+version = "2.0.0-dev"
 edition = "2021"
 
 [dependencies]
@@ -19,3 +19,4 @@ chrono = "0.4"
 souvlaki = { version = "0.8.0", default-features = false, features = ["use_zbus"] }
 color-thief = "0.2"
 rand = "0.9.0"
+sqlx = { version = "0.8", default-features = false, features = [ "runtime-tokio", "sqlite", "migrate"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,7 @@ HTTP client for Jellyfin API
     - All the types used in the client are defined at the end of the file.
 -------------------------- */
 
+use crate::database::app_extension::DownloadStatus;
 use crate::keyboard::Searchable;
 use chrono::NaiveDate;
 use dirs::cache_dir;
@@ -1416,17 +1417,17 @@ pub struct DiscographySong {
     #[serde(rename = "ArtistItems", default)]
     pub artist_items: Vec<Artist>,
     #[serde(rename = "Artists", default)]
-    artists: Vec<String>,
+    pub artists: Vec<String>,
     #[serde(rename = "BackdropImageTags", default)]
-    backdrop_image_tags: Vec<String>,
+    pub backdrop_image_tags: Vec<String>,
     #[serde(rename = "ChannelId", default)]
-    channel_id: Option<String>,
+    pub channel_id: Option<String>,
     #[serde(rename = "DateCreated", default)]
-    date_created: String,
+    pub date_created: String,
     // #[serde(rename = "GenreItems")]
     // genre_items: Vec<Genre>,
     #[serde(rename = "Genres", default)]
-    genres: Vec<String>,
+    pub genres: Vec<String>,
     #[serde(rename = "HasLyrics", default)]
     pub has_lyrics: bool,
     #[serde(rename = "Id", default)]
@@ -1440,17 +1441,17 @@ pub struct DiscographySong {
     #[serde(rename = "IndexNumber", default = "index_default")]
     pub index_number: u64,
     #[serde(rename = "IsFolder", default)]
-    is_folder: bool,
+    pub is_folder: bool,
     // #[serde(rename = "LocationType")]
     // location_type: String,
     #[serde(rename = "MediaSources", default)]
-    media_sources: Vec<MediaSource>,
+    pub media_sources: Vec<MediaSource>,
     #[serde(rename = "MediaType", default)]
-    media_type: String,
+    pub media_type: String,
     #[serde(rename = "Name", default)]
     pub name: String,
     #[serde(rename = "NormalizationGain", default)]
-    normalization_gain: f64,
+    pub normalization_gain: f64,
     // #[serde(rename = "ParentBackdropImageTags")]
     // parent_backdrop_image_tags: Vec<String>,
     // #[serde(rename = "ParentBackdropItemId")]
@@ -1460,17 +1461,20 @@ pub struct DiscographySong {
     #[serde(rename = "ParentIndexNumber", default = "index_default")]
     pub parent_index_number: u64,
     #[serde(rename = "PremiereDate", default)]
-    premiere_date: String,
+    pub premiere_date: String,
     #[serde(rename = "ProductionYear", default)]
     pub production_year: u64,
     #[serde(rename = "RunTimeTicks", default)]
     pub run_time_ticks: u64,
     #[serde(rename = "ServerId", default)]
-    server_id: String,
+    pub server_id: String,
     // #[serde(rename = "Type")]
     // type_: String,
     #[serde(rename = "UserData", default)]
     pub user_data: DiscographySongUserData,
+    /// our own fields
+    #[serde(skip)]
+    pub download_status: DownloadStatus,
 }
 
 impl Searchable for DiscographySong {

--- a/src/database/app_extension.rs
+++ b/src/database/app_extension.rs
@@ -1,0 +1,246 @@
+use serde::{Deserialize, Serialize};
+
+use sqlx::{migrate::MigrateDatabase, Sqlite, SqlitePool};
+
+use crate::{client::DiscographySong, tui};
+
+use super::database::Status;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub enum DownloadStatus {
+    Downloaded,
+    Queued,
+    Downloading { progress: f32 },
+    #[default]
+    NotDownloaded,
+}
+
+impl tui::App {
+    pub async fn handle_database_events(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let db = match self.db {
+            Some(ref mut db) => db,
+            None => return Ok(()),
+        };
+
+        
+        let status = db.status_rx.try_recv();
+        match status {
+            Ok(status) => self.handle_database_status(status).await,
+            Err(_) => return Ok(()),
+        }
+        Ok(())
+    }
+
+    async fn handle_database_status(&mut self, status: Status) {
+        match status {
+            Status::TrackDownloaded { id } => {
+                if let Some(track) = self.tracks.iter_mut().find(|t| t.id == id) {
+                    track.download_status = DownloadStatus::Downloaded;
+                } else {
+                    panic!("Track not found: {}", id);
+                }
+            }
+        }
+    }
+
+    /// Create a database if it doesn't exist. Perform any necessary initialization / migrations etc
+    /// 
+    pub async fn init_db(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let path = "sqlite://music.db";
+        if !Sqlite::database_exists(path).await.unwrap_or(false) {
+            println!(" ! Creating database {}", path);
+            match Sqlite::create_database(path).await {
+                Ok(_) => println!(" - Create db success."),
+                // TODO
+                Err(error) => panic!("error: {}", error),
+            }
+            let pool = SqlitePool::connect(path).await?;
+            create_tracks_table(&pool).await?;
+            create_artists_table(&pool).await?;
+            create_albums_table(&pool).await?;
+        }
+        Ok(())
+    }
+}
+
+/// ------------ helpers ------------
+/// 
+pub async fn create_tracks_table(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS tracks (
+            -- Basic text fields
+            id TEXT PRIMARY KEY,
+            album TEXT NOT NULL,
+            album_artist TEXT NOT NULL,
+            album_id TEXT NOT NULL,
+            date_created TEXT NOT NULL,
+            media_type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            parent_id TEXT NOT NULL,
+            premiere_date TEXT NOT NULL,
+            server_id TEXT NOT NULL,
+            
+            -- Fields stored as JSON (Vec<T> or custom types)
+            album_artists TEXT NOT NULL,  -- JSON array of Artist objects
+            artist_items TEXT NOT NULL,   -- JSON array of Artist objects
+            artists TEXT NOT NULL,        -- JSON array of strings
+            backdrop_image_tags TEXT NOT NULL,  -- JSON array of strings
+            genres TEXT NOT NULL,         -- JSON array of strings
+            media_sources TEXT NOT NULL,  -- JSON array of MediaSource objects
+            user_data TEXT NOT NULL,      -- JSON object for DiscographySongUserData
+
+            -- Optional field
+            channel_id TEXT,
+
+            -- Boolean values stored as INTEGER (0/1)
+            has_lyrics INTEGER NOT NULL,
+            is_folder INTEGER NOT NULL,
+
+            -- Numeric fields
+            index_number INTEGER NOT NULL,
+            parent_index_number INTEGER NOT NULL,
+            normalization_gain REAL NOT NULL,
+            production_year INTEGER NOT NULL,
+            run_time_ticks INTEGER NOT NULL,
+            
+            -- Other text fields
+            playlist_item_id TEXT NOT NULL
+        );
+        "#
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn create_artists_table(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS artists (
+            -- Primary key (adjust if needed)
+            id TEXT PRIMARY KEY,
+            
+            -- Basic text fields
+            name TEXT NOT NULL,
+            type_ TEXT NOT NULL,
+            location_type TEXT NOT NULL,
+            media_type TEXT NOT NULL,
+            
+            -- Numeric field
+            run_time_ticks INTEGER NOT NULL,
+            
+            -- JSON fields stored as TEXT
+            user_data TEXT NOT NULL,
+            image_tags TEXT NOT NULL,
+            image_blur_hashes TEXT NOT NULL,
+            
+            -- Boolean stored as INTEGER (0 for false, 1 for true)
+            jellyfintui_recently_added INTEGER NOT NULL
+        );
+        "#
+    )
+    .execute(pool)
+    .await?;
+    
+    Ok(())
+}
+
+pub async fn create_albums_table(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS albums (
+            -- Primary key for the album
+            id TEXT PRIMARY KEY,
+            
+            -- Basic text fields
+            name TEXT NOT NULL,
+            date_created TEXT NOT NULL,
+            parent_id TEXT NOT NULL,
+            
+            -- JSON fields stored as TEXT
+            album_artists TEXT NOT NULL,
+            user_data TEXT NOT NULL,
+            
+            -- Numeric field
+            run_time_ticks INTEGER NOT NULL
+        );
+        "#
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn insert_track(pool: &SqlitePool, track: &DiscographySong) -> Result<(), Box<dyn std::error::Error>> {
+    sqlx::query(
+        r#"
+        INSERT INTO tracks (
+            id,
+            album,
+            album_artist,
+            album_id,
+            date_created,
+            media_type,
+            name,
+            parent_id,
+            premiere_date,
+            server_id,
+            album_artists,
+            artist_items,
+            artists,
+            backdrop_image_tags,
+            genres,
+            media_sources,
+            user_data,
+            channel_id,
+            has_lyrics,
+            is_folder,
+            index_number,
+            parent_index_number,
+            normalization_gain,
+            production_year,
+            run_time_ticks,
+            playlist_item_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "#
+    )
+    .bind(&track.id)
+    .bind(&track.album)
+    .bind(&track.album_artist)
+    .bind(&track.album_id)
+    .bind(&track.date_created)
+    .bind(&track.media_type)
+    .bind(&track.name)
+    .bind(&track.parent_id)
+    .bind(&track.premiere_date)
+    .bind(&track.server_id)
+    // Serialize JSON fields
+    .bind(serde_json::to_string(&track.album_artists)?)
+    .bind(serde_json::to_string(&track.artist_items)?)
+    .bind(serde_json::to_string(&track.artists)?)
+    .bind(serde_json::to_string(&track.backdrop_image_tags)?)
+    .bind(serde_json::to_string(&track.genres)?)
+    .bind(serde_json::to_string(&track.media_sources)?)
+    .bind(serde_json::to_string(&track.user_data)?)
+    // Optional channel_id
+    .bind(track.channel_id.as_ref())
+    // Booleans as integers
+    .bind(track.has_lyrics as i32)
+    .bind(if track.is_folder { 1 } else { 0 })
+    // Numeric fields
+    .bind(track.index_number as i64)
+    .bind(track.parent_index_number as i64)
+    .bind(track.normalization_gain)
+    .bind(track.production_year as i64)
+    .bind(track.run_time_ticks as i64)
+    .bind(&track.playlist_item_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+

--- a/src/database/database.rs
+++ b/src/database/database.rs
@@ -1,0 +1,68 @@
+use sqlx::SqlitePool;
+use tokio::sync::mpsc::{error::TryRecvError, Receiver, Sender};
+
+use crate::client::DiscographySong;
+
+use super::app_extension::insert_track;
+
+#[derive(Debug)]
+pub enum Command {
+    Download(DownloadCommand),
+    Update(UpdateCommand),
+    Delete(DeleteCommand),
+}
+
+pub enum Status {
+    TrackDownloaded { id: String },
+}
+
+#[derive(Debug)]
+pub enum DownloadCommand {
+    Track { track: DiscographySong },
+    Album { id: u32, album_url: String },
+    Playlist { id: u32, playlist_url: String },
+}
+
+#[derive(Debug)]
+enum UpdateCommand {
+    Song { id: u32, url: String },
+    Album { id: u32, album_url: String },
+    Playlist { id: u32, playlist_url: String },
+}
+
+#[derive(Debug)]
+enum DeleteCommand {
+    Song { id: u32 },
+    Album { id: u32 },
+    Playlist { id: u32 },
+}
+
+pub async fn t_database(
+    mut rx: Receiver<Command>,
+    tx: Sender<Status>,
+) {
+
+    let pool = SqlitePool::connect("sqlite://music.db").await.unwrap();
+
+    loop {
+        let status = rx.try_recv();
+        match status {
+            Ok(Command::Download(cmd)) => {
+                match cmd {
+                    DownloadCommand::Track { track } => {
+                        let _ = insert_track(&pool, &track).await;
+                        tx.send(Status::TrackDownloaded { id: track.id }).await.unwrap();
+                    }
+                    _ => {}
+                }
+            }
+            Err(e) => {
+                if e != TryRecvError::Empty {
+                    println!("{:?}", e);
+                }
+            },
+            _ => {},
+        }
+        tokio::time::sleep(std::time::Duration::from_secs_f32(0.2)).await;
+    }
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,0 +1,2 @@
+pub mod app_extension;
+pub mod database;

--- a/src/library.rs
+++ b/src/library.rs
@@ -12,6 +12,7 @@ Main Library tab
 -------------------------- */
 
 use crate::client::{Album, Artist, DiscographySong};
+use crate::database::app_extension::DownloadStatus;
 use crate::{helpers, keyboard::*};
 use crate::tui::{App, Repeat};
 
@@ -830,6 +831,7 @@ impl App {
                         Cell::from(">>"),
                         Cell::from(title),
                         Cell::from(""),
+                        Cell::from(""),
                         Cell::from(if track.user_data.is_favorite {
                             "♥".to_string()
                         } else {
@@ -903,6 +905,12 @@ impl App {
                         Line::from(title)
                     }),
                     Cell::from(track.album.clone()),
+                    Cell::from(match track.download_status {
+                        DownloadStatus::Downloaded => Line::from("✓").fg(self.primary_color),
+                        DownloadStatus::Queued => Line::from("⇊").yellow(),
+                        DownloadStatus::Downloading { progress } => Line::from(format!("{:.0}%", progress)),
+                        DownloadStatus::NotDownloaded => Line::from(""),
+                    }),
                     Cell::from(if track.user_data.is_favorite {
                         "♥".to_string()
                     } else {
@@ -944,6 +952,7 @@ impl App {
             Constraint::Length(items.len().to_string().len() as u16 + 1),
             Constraint::Percentage(75), // title and track even width
             Constraint::Percentage(25),
+            Constraint::Length(2),
             Constraint::Length(2),
             Constraint::Length(5),
             Constraint::Length(5),
@@ -1011,7 +1020,7 @@ impl App {
             .style(Style::default().bg(Color::Reset))
             .header(
                 Row::new(vec![
-                    "#", "Title", "Album", "♥", "Plays", "Disc", "Lyrics", "Duration",
+                    "#", "Title", "Album", "⇊", "♥", "Plays", "Disc", "Lyrics", "Duration",
                 ])
                 .style(Style::new().bold().white())
                 .bottom_margin(0),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod client;
 mod config;
+mod database;
 mod help;
 mod helpers;
 mod keyboard;


### PR DESCRIPTION
This PR introduces offline support. This will be a huge update and will take some time to finish.

Requirements check:
- [x] Add a database
- [x] Add a thread and 2 mutexes to send status commands (DownoadCommand -> PROCESS -> DownloadStatus)
- [ ] Implement database actions for queueing a download
- [ ] Spawn new threads for each individual media download, sync them to the db and emit DownloadStatus when they finish.
- [ ] Add an offline mode (start up without internet and query the database for music to play)
- [ ] Cache eviction by user choice (delete if not listened to for X days/months, delete if over X GB in size, etc)
- [ ] Failsaves making sure a download resumes when the app reopens

Nice to have:
- [ ] Sync changes when coming back online (if a user liked a song while offline, sync upwards later)
- [ ] Allow downloading of specific transcode / format
- [ ] Internet loss detection