### PR TITLE
fix: fixed authorization header

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -106,7 +106,7 @@ impl Client {
             "Authorization".into(),
             format!(
                 "MediaBrowser Client=\"{}\", Device=\"{}\", DeviceId=\"{}\", Version=\"{}\", Token=\"{}\"",
-                env!("CARGO_PKG_VERSION"), "jellyfin-tui", "jellyfin-tui", device_id, access_token
+                "jellyfin-tui", "jellyfin-tui", device_id, env!("CARGO_PKG_VERSION"), access_token
             )
         )
     }


### PR DESCRIPTION
Authorization header format arguments were in the wrong order, which caused various issues with multiple users.