### PR TITLE
fix: crash when hitting enter on empty queue

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -400,6 +400,9 @@ impl App {
     /// If we play a song *inside* the queue, we just play it
     ///
     pub async fn relocate_queue_and_play(&mut self) {
+        if self.state.queue.is_empty() {
+            return;
+        }
         if let Ok(mpv) = self.mpv_state.lock() {
             // get a list of all the songs in the queue
             let mut queue: Vec<Song> = self


### PR DESCRIPTION
Fixes #61 
I'm inexperienced with both Rust and this codebase, let me know if there's a better way to do this