### PR TITLE
Config option to read password from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ servers:
     url: 'http://localhost:8096'
     username: 'username'
     password: 'imcool123'
+  - name: Third Server
+    url: 'http:/jellyfin.example2.com'
+    username: 'username'
+    password_file: /home/myusername/.jellyfin-tui-password # use a file containing the password
 
 # All following settings are OPTIONAL. What you see here are the defaults.
 


### PR DESCRIPTION
This pr adds `password_file` as a valid key to a server entry in `config.yaml`. When specified, it reads the password from the specified file.

The use case for this is environments like Nix, especially home-manager and/or https://github.com/ryantm/agenix where secrets are decrypted to files.


```yaml
servers:
  - name: Server
    url: 'http:/jellyfin.example.com'
    username: 'username'
    password_file: /some/path/to/a/file
```