### PR TITLE
Handle non-existent cache folder in the CrossesDevices case

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -46,8 +46,12 @@ pub fn prepare_directories() -> Result<(), Box<dyn std::error::Error>> {
             return Err(Box::new(std::io::Error::new(e.kind(), e.to_string())));
         },
         Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
-            fs_extra::dir::copy(&j_cache_dir, &j_data_dir, &fs_extra::dir::CopyOptions::new().content_only(true))?;
-            std::fs::remove_dir_all(&j_cache_dir)?;
+            if std::fs::metadata(&j_cache_dir).is_ok() == true {
+                fs_extra::dir::copy(&j_cache_dir, &j_data_dir, &fs_extra::dir::CopyOptions::new().content_only(true))?;
+                std::fs::remove_dir_all(&j_cache_dir)?;
+            } else {
+                return Ok(());
+            }
         },
         Err(e) => return Err(Box::new(e))
     };


### PR DESCRIPTION
For some reason, ErrorKind::CrossesDevices seems to get priority over ErrorKind::NotFound. In a situation where the cache folder is on a separate storage device/filesystem/zfs dataset, CrossesDevices gets triggered first or by default. If the cache folder does not exist, the whole rename function errors out when it tries to move anything/everything in the cache folder when handling the CrossesDevices case. Then jellyfin-tui catches the error and simply stops running (as far as I understand it).

This commit adds a check for the jellyfin-tui cache folder within the CrossesDevices case so that it does not attempt to move a non-existent folder when the CrossesDevices case is triggered.