### PR TITLE
fix: do full redraw on SIGWINCH if terminal's size hasn't changed

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -104,11 +104,19 @@ impl App {
                     self.recent_input_activity = tokio::time::Instant::now();
                     self.handle_mouse_event(m);
                 }
-                Event::Resize(_, _) => {
+                Event::Resize(c, r) => {
                     let (_, picker) = App::init_theme_and_picker(&self.config, &self.theme);
                     self.picker = picker;
                     self.refresh_cover_art().await;
-                    self.dirty = true;
+                    if c == self.last_term_size.0 && r == self.last_term_size.1 {
+                        // Size hasn't changed. Do a full redraw in case we are running under a terminal
+                        // session manager which just restored  the session.
+                        self.dirty_clear = true;
+                    } else {
+                        // Size has changed. So redraw whatever needs to be redrawn.
+                        self.dirty = true;
+                    }
+                    self.last_term_size = (c, r);
                 }
                 _ => {}
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -265,6 +265,8 @@ pub struct App {
     should_scrobble: bool,        // flag to track if we should scrobble the current song
     pub controls: Option<MediaControls>,
     pub db: DatabaseWrapper,
+
+    pub last_term_size: (u16, u16), // Last known terminal size used to trigger full redraw
 }
 
 impl App {
@@ -506,6 +508,8 @@ impl App {
             controls,
 
             db,
+
+            last_term_size: (0, 0),
         }
     }
 }
@@ -2093,6 +2097,8 @@ impl App {
     }
 
     pub async fn load_state(&mut self) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        self.last_term_size = crossterm::terminal::size()?;
+
         self.state.artists_scroll_state = ScrollbarState::new(self.artists.len().saturating_sub(1));
         self.state.active_section = ActiveSection::List;
         self.state.selected_artist.select_first();


### PR DESCRIPTION
Various terminal session managers, like dtach, use SIGWINCH to signal
an app to redraw its state when a session is restored. Since from
ratatui point of view nothing really changed, only a small portion of
the screen gets redrawn:

```
// Start jellyfin-tui under dtach to let it run in the background
$ dtach -A jellyfin-tui.dtach -r winch jellyfin-tui
// kill the term here
// And re-attach in a new terminal window
$ dtach -a jellyfin-tui.dtach
```

To compensate for this, clear the terminal and do a full redraw if the
resize even indicates that the terminal size hasn't really changed.
