### PR TITLE
fix: cli flags not working with an instance open

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,6 @@ use ratatui::prelude::{CrosstermBackend, Terminal};
 
 #[tokio::main]
 async fn main() {
-    let _lockfile = check_single_instance();
-
     let version = env!("CARGO_PKG_VERSION");
 
     let args = env::args().collect::<Vec<String>>();
@@ -61,6 +59,8 @@ async fn main() {
             return;
         }
     }
+
+    let _lockfile = check_single_instance();
 
     let offline = args.contains(&String::from("--offline"));
     let force_server_select = args.contains(&String::from("--select-server"));


### PR DESCRIPTION
check the lockfile after --version and --help logic to allow usage with a running instance