### PR TITLE
fix: Jellyfin 10.12 compatibility — update deprecated auth methods

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,12 +15,16 @@
     {
       nixpkgs,
       systems,
-      self,
       rust-overlay,
       ...
     }:
     let
       package =
+        let
+          cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
+          pname = cargoToml.package.name;
+          version = cargoToml.package.version;
+        in
         {
           lib,
           stdenv,
@@ -32,8 +36,8 @@
           writableTmpDirAsHomeHook,
         }:
         rustPlatform.buildRustPackage {
-          pname = "jellyfin-tui";
-          version = self.shortRev or self.dirtyShortRev or "dirty";
+          inherit pname;
+          inherit version;
 
           src = lib.fileset.toSource {
             root = ./.;
@@ -96,12 +100,12 @@
             rustc = toolchain;
           };
 
-          jellyfin-tui = pkgs.callPackage package {
-            rustPlatform = customRustPlatform;
-          };
+          jellyfin-tui = pkgs.callPackage package { rustPlatform = customRustPlatform; };
         in
         {
           default = jellyfin-tui;
+
+          inherit jellyfin-tui;
 
           debug = jellyfin-tui.overrideAttrs (
             newAttrs: oldAttrs: {
@@ -121,17 +125,13 @@
         { pkgs, toolchain }:
         {
           default = pkgs.mkShell {
-
-            packages = [ toolchain ];
-
-            nativeBuildInputs = [ pkgs.pkg-config ];
-
-            buildInputs = with pkgs; [
+            packages = with pkgs; [
+              toolchain
               openssl
               mpv
               sqlite
+              pkg-config
             ];
-
             env = {
               OPENSSL_DIR = "${pkgs.openssl.dev}";
               OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";

--- a/src/client.rs
+++ b/src/client.rs
@@ -286,7 +286,6 @@ impl Client {
         let req = self
             .http_client
             .get(&url)
-            .header("X-MediaBrowser-Token", &self.access_token)
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str());
 
         let views: ViewsResponse = match self.get_json_with_retry(req).await {
@@ -321,7 +320,6 @@ impl Client {
         let req = self
             .http_client
             .get(&url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "text/json")
             .query(&[
@@ -346,7 +344,6 @@ impl Client {
         let favorite_req = self
             .http_client
             .get(&url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "text/json")
             .query(&[("Filters", "IsFavorite"), ("StartIndex", "0")]);
@@ -386,7 +383,6 @@ impl Client {
                 let mut req = self
                     .http_client
                     .get(&url)
-                    .header("X-MediaBrowser-Token", self.access_token.to_string())
                     .header(
                         self.authorization_header.0.as_str(),
                         self.authorization_header.1.as_str(),
@@ -460,7 +456,6 @@ impl Client {
         let req = self
             .http_client
             .get(&url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "text/json")
             .query(&[
@@ -500,7 +495,6 @@ impl Client {
         let req = self
             .http_client
             .get(&url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "text/json")
             .query(&[
@@ -536,7 +530,6 @@ impl Client {
         let req = self
             .http_client
             .get(&url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "text/json")
             .query(&[
@@ -595,7 +588,6 @@ impl Client {
         let req = self
             .http_client
             .get(&url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "text/json")
             .query(&[
@@ -639,7 +631,6 @@ impl Client {
         let mut req = self
             .http_client
             .get(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .query(&[("Fields", "Genres, DateCreated, MediaSources, ParentId")]);
 
@@ -676,7 +667,6 @@ impl Client {
         let req = self
             .http_client
             .get(&url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json");
 
@@ -705,7 +695,6 @@ impl Client {
         let response = self
             .http_client
             .get(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .send()
@@ -743,7 +732,7 @@ impl Client {
     pub fn song_url_sync(&self, song_id: &String, transcoding: Option<&Transcoding>) -> String {
         let mut url = format!("{}/Audio/{}/universal", self.base_url, song_id);
         url += &format!(
-            "?UserId={}&api_key={}&StartTimeTicks=0&EnableRedirection=true&EnableRemoteMedia=false",
+            "?UserId={}&ApiKey={}&StartTimeTicks=0&EnableRedirection=true&EnableRemoteMedia=false",
             self.user_id, self.access_token
         );
         url += "&container=opus,webm|opus,mp3,aac,m4a|aac,m4a|alac,m4b|aac,flac,webma,webm|webma,wav,ogg,wv|wavpack";
@@ -772,7 +761,6 @@ impl Client {
         let response = if favorite {
             self.http_client
                 .post(url)
-                .header("X-MediaBrowser-Token", self.access_token.to_string())
                 .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
                 .header("Content-Type", "application/json")
                 .send()
@@ -780,7 +768,6 @@ impl Client {
         } else {
             self.http_client
                 .delete(url)
-                .header("X-MediaBrowser-Token", self.access_token.to_string())
                 .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
                 .header("Content-Type", "application/json")
                 .send()
@@ -811,7 +798,6 @@ impl Client {
             let req = self
                 .http_client
                 .get(&url)
-                .header("X-MediaBrowser-Token", self.access_token.to_string())
                 .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
                 .query(&[
                     ("SortBy", "Name"),
@@ -885,7 +871,6 @@ impl Client {
             let req = self
                 .http_client
                 .get(&url)
-                .header("X-MediaBrowser-Token", self.access_token.to_string())
                 .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
                 .header("Content-Type", "text/json")
                 .query(&query_params);
@@ -961,7 +946,6 @@ impl Client {
         let response = self
             .http_client
             .post(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .json(&serde_json::json!({
@@ -988,7 +972,6 @@ impl Client {
 
         self.http_client
             .delete(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .send()
@@ -1008,7 +991,6 @@ impl Client {
         let response = self
             .http_client
             .get(url.clone())
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .send()
@@ -1020,7 +1002,6 @@ impl Client {
 
         self.http_client
             .post(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .json(&full_playlist)
@@ -1040,7 +1021,6 @@ impl Client {
 
         self.http_client
             .post(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .query(&[("ids", track_id), ("userId", self.user_id.as_str())])
@@ -1059,7 +1039,6 @@ impl Client {
 
         self.http_client
             .delete(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .query(&[("EntryIds", track_id)])
@@ -1080,7 +1059,6 @@ impl Client {
 
         self.http_client
             .post(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .send()
@@ -1095,7 +1073,6 @@ impl Client {
         let req = self
             .http_client
             .get(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .query(&[("isHidden", "false")]);
@@ -1119,7 +1096,6 @@ impl Client {
 
         self.http_client
             .post(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .send()
@@ -1133,7 +1109,6 @@ impl Client {
         let _response = self
             .http_client
             .post(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .json(&serde_json::json!({
@@ -1167,7 +1142,6 @@ impl Client {
             .http_client
             .post(url)
             .timeout(Duration::from_millis(300))
-            .header("X-MediaBrowser-Token", &self.access_token)
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .json(&body)
@@ -1185,7 +1159,6 @@ impl Client {
         let client = reqwest::Client::new();
         let _response = client
             .post(url)
-            .header("X-MediaBrowser-Token", self.access_token.to_string())
             .header(self.authorization_header.0.as_str(), self.authorization_header.1.as_str())
             .header("Content-Type", "application/json")
             .json(&serde_json::json!({


### PR DESCRIPTION
## Summary

Fixes playback failure (HTTP 401 on every stream request) when using Jellyfin 10.12, which disables legacy authorization by default.

- **`api_key` → `ApiKey`** in stream URLs — the lowercase query parameter is deprecated in 10.12 (disabled by default) and removed in 10.13. This was the primary cause of silent playback failure and rapid track skipping.
- **Remove `X-MediaBrowser-Token` headers** from all 27 API call sites — the correct `Authorization: MediaBrowser ... Token="..."` header is already sent on every request. Sending both simultaneously can cause 401 errors on 10.12+ (see jellyfin/jellyfin#16086).

## Context

Jellyfin's legacy auth deprecation timeline:
- **10.11**: Added `EnableLegacyAuthorization` option (default: `true`)
- **10.12**: Changed default to `false` ← **breaks jellyfin-tui**
- **10.13**: Legacy methods permanently removed

## Test plan

- [x] Tested against Jellyfin 10.12.0 — playback works, no 401 errors
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] Clippy warnings are all pre-existing (104 warnings before and after)

Closes #177

Unsure whether you allow AI based PR's or not. Feel free to reject if that's not the case.

> I manually tested playback and seemed to work just fine for me in a nix environment, but I have simple usage and didn't test advanced features.