### PR TITLE
Vertical layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2037,7 +2037,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix 0.29.0",
+ "nix",
  "winapi",
 ]
 
@@ -2146,7 +2146,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -2726,7 +2726,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2764,7 +2764,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3632,7 +3632,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -3984,7 +3984,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix 0.29.0",
+ "nix",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -4121,7 +4121,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -448,10 +448,16 @@ pub struct Preferences {
     #[serde(default = "Preferences::default_theme")]
     pub theme: String,
 
-    // here we define the preferred percentage splits for each section. Must add up to 100.
-    #[serde(default = "Preferences::default_music_column_widths")]
-    // (List, Tracks, Lyrics+Queue). In vertical mode these drive heights instead of widths.
-    pub constraint_width_percentages_music: (u16, u16, u16),
+    // (List, Tracks, Lyrics+Queue) width percentages for the horizontal layout. Must add up to 100.
+    #[serde(
+        default = "Preferences::default_horizontal_pane_ratios",
+        alias = "constraint_width_percentages_music"
+    )]
+    pub horizontal_pane_ratios: (u16, u16, u16),
+
+    // (List, Tracks, Queue) height percentages for the vertical layout. Must add up to 100.
+    #[serde(default = "Preferences::default_vertical_pane_ratios")]
+    pub vertical_pane_ratios: (u16, u16, u16),
 
     #[serde(default = "Preferences::default_instant_playlist_size")]
     pub instant_playlist_size: usize,
@@ -494,7 +500,8 @@ impl Preferences {
 
             theme: String::from("Dark"),
 
-            constraint_width_percentages_music: (22, 56, 22),
+            horizontal_pane_ratios: Self::default_horizontal_pane_ratios(),
+            vertical_pane_ratios: Self::default_vertical_pane_ratios(),
 
             instant_playlist_size: 100,
             radio_mode: RadioMode::default(),
@@ -505,8 +512,12 @@ impl Preferences {
         }
     }
 
-    pub fn default_music_column_widths() -> (u16, u16, u16) {
+    pub fn default_horizontal_pane_ratios() -> (u16, u16, u16) {
         (22, 56, 22)
+    }
+
+    pub fn default_vertical_pane_ratios() -> (u16, u16, u16) {
+        (30, 45, 25)
     }
 
     fn default_theme() -> String {
@@ -537,7 +548,12 @@ impl Preferences {
             return;
         }
 
-        let (a, b, c) = &mut self.constraint_width_percentages_music;
+        let ratios = if is_vertical {
+            &mut self.vertical_pane_ratios
+        } else {
+            &mut self.horizontal_pane_ratios
+        };
+        let (a, b, c) = (&mut ratios.0, &mut ratios.1, &mut ratios.2);
 
         match active_section {
             ActiveSection::List => {
@@ -570,7 +586,7 @@ impl Preferences {
             _ => {}
         }
 
-        Self::normalize(&mut self.constraint_width_percentages_music);
+        Self::normalize(ratios);
     }
 
     fn normalize(p: &mut (u16, u16, u16)) {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -450,7 +450,8 @@ pub struct Preferences {
 
     // here we define the preferred percentage splits for each section. Must add up to 100.
     #[serde(default = "Preferences::default_music_column_widths")]
-    pub constraint_width_percentages_music: (u16, u16, u16), // (Artists, Albums, Tracks)
+    // (List, Tracks, Lyrics+Queue). In vertical mode these drive heights instead of widths.
+    pub constraint_width_percentages_music: (u16, u16, u16),
 
     #[serde(default = "Preferences::default_instant_playlist_size")]
     pub instant_playlist_size: usize,
@@ -524,7 +525,18 @@ impl Preferences {
         30
     }
 
-    pub(crate) fn widen_current_pane(&mut self, active_section: &ActiveSection, up: bool) {
+    pub(crate) fn widen_current_pane(
+        &mut self,
+        active_section: &ActiveSection,
+        up: bool,
+        is_vertical: bool,
+    ) {
+        // In vertical mode the lyrics slot is fixed-height, so resizing from
+        // the Lyrics pane would silently shift unrelated panes — skip it.
+        if is_vertical && matches!(active_section, ActiveSection::Lyrics) {
+            return;
+        }
+
         let (a, b, c) = &mut self.constraint_width_percentages_music;
 
         match active_section {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -131,6 +131,10 @@ pub enum Action {
     WidenPane,
     /// Shrink current pane
     ShrinkPane,
+    /// Make current pane taller
+    HeightenPane,
+    /// Make current pane shorter
+    ShortenPane,
 
     /// Exit the app
     Quit,
@@ -199,6 +203,8 @@ impl Action {
             Action::GlobalPopup => Cow::Borrowed("Open global popup"),
             Action::WidenPane => Cow::Borrowed("Widen pane"),
             Action::ShrinkPane => Cow::Borrowed("Shrink pane"),
+            Action::HeightenPane => Cow::Borrowed("Grow pane height"),
+            Action::ShortenPane => Cow::Borrowed("Shrink pane height"),
             Action::Help => Cow::Borrowed("Open help"),
             // System
             Action::Quit => Cow::Borrowed("Quit application"),
@@ -257,7 +263,9 @@ impl Action {
             | Action::Popup
             | Action::GlobalPopup
             | Action::WidenPane
-            | Action::ShrinkPane => ActionCategory::UI,
+            | Action::ShrinkPane
+            | Action::HeightenPane
+            | Action::ShortenPane => ActionCategory::UI,
 
             Action::Quit | Action::Shell(_) | Action::Reset => ActionCategory::System,
         }
@@ -309,6 +317,10 @@ const DEFAULT_BINDINGS: &[(KeyCombination, Action)] = &[
     (key!(ctrl - left), Action::ShrinkPane),
     (key!(ctrl - l), Action::WidenPane),
     (key!(ctrl - h), Action::ShrinkPane),
+    (key!(ctrl - up), Action::HeightenPane),
+    (key!(ctrl - down), Action::ShortenPane),
+    (key!(ctrl - k), Action::HeightenPane),
+    (key!(ctrl - j), Action::ShortenPane),
     // playback
     (key!('n'), Action::Next),
     (key!(shift - n), Action::Previous),
@@ -510,10 +522,28 @@ impl App {
             Action::NextPane => self.step_section(true),
             Action::PreviousPane => self.step_section(false),
             Action::WidenPane => {
-                self.preferences.widen_current_pane(&self.state.active_section, true)
+                let is_vertical = self.last_term_size.0 < crate::library::VERTICAL_LAYOUT_THRESHOLD;
+                if !is_vertical {
+                    self.preferences.widen_current_pane(&self.state.active_section, true, false)
+                }
             }
             Action::ShrinkPane => {
-                self.preferences.widen_current_pane(&self.state.active_section, false)
+                let is_vertical = self.last_term_size.0 < crate::library::VERTICAL_LAYOUT_THRESHOLD;
+                if !is_vertical {
+                    self.preferences.widen_current_pane(&self.state.active_section, false, false)
+                }
+            }
+            Action::HeightenPane => {
+                let is_vertical = self.last_term_size.0 < crate::library::VERTICAL_LAYOUT_THRESHOLD;
+                if is_vertical {
+                    self.preferences.widen_current_pane(&self.state.active_section, true, true)
+                }
+            }
+            Action::ShortenPane => {
+                let is_vertical = self.last_term_size.0 < crate::library::VERTICAL_LAYOUT_THRESHOLD;
+                if is_vertical {
+                    self.preferences.widen_current_pane(&self.state.active_section, false, true)
+                }
             }
             Action::Next => self.next().await,
             Action::Previous => self.previous().await,

--- a/src/library.rs
+++ b/src/library.rs
@@ -1819,6 +1819,5 @@ impl App {
                 .style(Style::default().fg(self.theme.resolve(&self.theme.foreground))),
             progress_bar_area[1],
         );
-
     }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -93,7 +93,7 @@ impl App {
 
         self.render_library_left(frame, outer_layout);
         self.render_library_center(frame, &center);
-        self.render_player(frame, &center);
+        self.render_player(frame, &center, false);
         self.render_library_right(frame, right);
         self.create_popup(frame);
     }
@@ -133,7 +133,7 @@ impl App {
         self.render_library_center(frame, &center);
         self.render_library_queue(frame, outer[2]);
         self.render_download_bar(frame, outer[3]);
-        self.render_player(frame, &center);
+        self.render_player(frame, &center, true);
         self.create_popup(frame);
     }
 
@@ -1544,7 +1544,12 @@ impl App {
         frame.render_stateful_widget(table, center[0], &mut self.state.selected_album_track);
     }
 
-    pub fn render_player(&mut self, frame: &mut Frame, center: &std::rc::Rc<[Rect]>) {
+    pub fn render_player(
+        &mut self,
+        frame: &mut Frame,
+        center: &std::rc::Rc<[Rect]>,
+        is_vertical: bool,
+    ) {
         let current_song = self.state.queue.get(self.state.current_playback_state.current_index);
 
         let metadata_spans: Vec<Span> = current_song
@@ -1626,8 +1631,38 @@ impl App {
             .fg(self.theme.resolve(&self.theme.border))
             .padding(Padding::new(0, 0, 0, 0));
 
-        let inner = bottom.inner(center[1]);
+        let inner_full = bottom.inner(center[1]);
         frame.render_widget(bottom, center[1]);
+
+        // In vertical mode with large_art + a loaded cover, render the artwork
+        // on the left of the strip with width derived from the natural aspect
+        // ratio. Player bar takes the remaining width.
+        let vertical_artwork: Option<Rect> = if is_vertical
+            && self.preferences.large_art
+            && self.cover_art.is_some()
+        {
+            let img_area = self
+                .cover_art
+                .as_mut()
+                .unwrap()
+                .size_for(Resize::Scale(None), inner_full);
+            let w = img_area.width.min(inner_full.width);
+            let h = img_area.height.min(inner_full.height);
+            Some(Rect { x: inner_full.x, y: inner_full.y, width: w, height: h })
+        } else {
+            None
+        };
+
+        let inner = if let Some(art) = vertical_artwork {
+            Rect {
+                x: inner_full.x.saturating_add(art.width),
+                y: inner_full.y,
+                width: inner_full.width.saturating_sub(art.width),
+                height: inner_full.height,
+            }
+        } else {
+            inner_full
+        };
 
         // split the bottom into two parts
         let bottom_split = Layout::default()
@@ -1807,5 +1842,10 @@ impl App {
                 .style(Style::default().fg(self.theme.resolve(&self.theme.foreground))),
             progress_bar_area[1],
         );
+
+        if let Some(art_area) = vertical_artwork {
+            let image = StatefulImage::default().resize(Resize::Scale(None));
+            frame.render_stateful_widget(image, art_area, self.cover_art.as_mut().unwrap());
+        }
     }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -93,7 +93,7 @@ impl App {
 
         self.render_library_left(frame, outer_layout);
         self.render_library_center(frame, &center);
-        self.render_player(frame, &center, false);
+        self.render_player(frame, &center, self.preferences.large_art);
         self.render_library_right(frame, right);
         self.create_popup(frame);
     }
@@ -135,7 +135,9 @@ impl App {
         self.render_library_center(frame, &center);
         self.render_library_queue(frame, outer[2]);
         self.render_download_bar(frame, outer[3]);
-        self.render_player(frame, &center, true);
+        // Vertical mode forces the small-cover sizing regardless of the
+        // `large_art` preference, so the player strip height stays fixed.
+        self.render_player(frame, &center, false);
         self.create_popup(frame);
     }
 
@@ -663,30 +665,8 @@ impl App {
         }
         self.render_library_queue(frame, right[1]);
 
-        if self.state.queue.is_empty() {
-            return;
-        }
-
-        if let Some(download_item) = &self.download_item {
-            let progress = (download_item.progress * 100.0).round() / 100.0;
-            let progress_text = format!("{:.1}%", progress);
-
-            let p = Paragraph::new(format!(
-                "{} {} - {}",
-                &self.spinner_stages[self.spinner], progress_text, &download_item.name,
-            ))
-            .style(Style::default().fg(self.theme.resolve(&self.theme.foreground)))
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(
-                        Line::from("Downloading").fg(self.theme.resolve(&self.theme.section_title)),
-                    )
-                    .border_type(self.border_type)
-                    .fg(self.theme.resolve(&self.theme.border)),
-            );
-
-            frame.render_widget(p, right[2]);
+        if !self.state.queue.is_empty() {
+            self.render_download_bar(frame, right[2]);
         }
     }
 
@@ -1550,7 +1530,7 @@ impl App {
         &mut self,
         frame: &mut Frame,
         center: &std::rc::Rc<[Rect]>,
-        is_vertical: bool,
+        large_art: bool,
     ) {
         let current_song = self.state.queue.get(self.state.current_playback_state.current_index);
 
@@ -1635,11 +1615,6 @@ impl App {
 
         let inner = bottom.inner(center[1]);
         frame.render_widget(bottom, center[1]);
-
-        // Vertical mode renders the cover beside the player bar using the
-        // small-cover variant regardless of `large_art`, so the preference is
-        // only honored in horizontal mode.
-        let large_art = self.preferences.large_art && !is_vertical;
 
         // split the bottom into two parts
         let bottom_split = Layout::default()

--- a/src/library.rs
+++ b/src/library.rs
@@ -26,8 +26,18 @@ use ratatui::{
 };
 use ratatui_image::{Resize, StatefulImage};
 
+/// When the Library tab's render area is narrower than this many columns,
+/// the layout switches from the three-column horizontal arrangement to a
+/// stacked vertical arrangement. See render_home_vertical.
+pub const VERTICAL_LAYOUT_THRESHOLD: u16 = 100;
+
 impl App {
     pub fn render_home(&mut self, app_container: Rect, frame: &mut Frame) {
+        if app_container.width < VERTICAL_LAYOUT_THRESHOLD {
+            self.render_home_vertical(app_container, frame);
+            return;
+        }
+
         let outer_layout = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(vec![
@@ -85,6 +95,42 @@ impl App {
         self.render_library_center(frame, &center);
         self.render_player(frame, &center);
         self.render_library_right(frame, right);
+        self.create_popup(frame);
+    }
+
+    /// Stacked layout used when the Library tab is narrower than
+    /// [`VERTICAL_LAYOUT_THRESHOLD`]. Artists/Albums (25%) on top, Tracks (50%)
+    /// in the middle, Queue (25%) below, and the player bar pinned to the
+    /// bottom. Lyrics, artwork and the download bar are intentionally omitted
+    /// here — see follow-up slices.
+    fn render_home_vertical(&mut self, app_container: Rect, frame: &mut Frame) {
+        let player_height = if self.preferences.large_art { 7 } else { 8 };
+
+        let outer = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![
+                Constraint::Percentage(25),
+                Constraint::Percentage(50),
+                Constraint::Percentage(25),
+                Constraint::Length(player_height),
+            ])
+            .split(app_container);
+
+        let left: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[0]]);
+        let center: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[1], outer[3]]);
+
+        match self.state.active_tab {
+            ActiveTab::Library => {
+                self.render_library_artists(frame, left);
+            }
+            ActiveTab::Albums => {
+                self.render_library_albums(frame, left);
+            }
+            _ => {}
+        }
+        self.render_library_center(frame, &center);
+        self.render_library_queue(frame, outer[2]);
+        self.render_player(frame, &center);
         self.create_popup(frame);
     }
 
@@ -587,6 +633,36 @@ impl App {
                 frame.render_stateful_widget(list, right[0], &mut self.state.selected_lyric);
             }
         }
+        self.render_library_queue(frame, right[1]);
+
+        if self.state.queue.is_empty() {
+            return;
+        }
+
+        if let Some(download_item) = &self.download_item {
+            let progress = (download_item.progress * 100.0).round() / 100.0;
+            let progress_text = format!("{:.1}%", progress);
+
+            let p = Paragraph::new(format!(
+                "{} {} - {}",
+                &self.spinner_stages[self.spinner], progress_text, &download_item.name,
+            ))
+            .style(Style::default().fg(self.theme.resolve(&self.theme.foreground)))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(
+                        Line::from("Downloading").fg(self.theme.resolve(&self.theme.section_title)),
+                    )
+                    .border_type(self.border_type)
+                    .fg(self.theme.resolve(&self.theme.border)),
+            );
+
+            frame.render_widget(p, right[2]);
+        }
+    }
+
+    pub fn render_library_queue(&mut self, frame: &mut Frame, area: Rect) {
         let queue_block = match self.state.active_section {
             ActiveSection::Queue => Block::new()
                 .borders(Borders::ALL)
@@ -598,7 +674,7 @@ impl App {
         .border_type(self.border_type);
 
         let total = self.state.queue.len();
-        let height = right[1].height.saturating_sub(2) as usize;
+        let height = area.height.saturating_sub(2) as usize;
 
         let current = self.state.current_playback_state.current_index;
         let auto_scroll = self.state.active_section != ActiveSection::Queue;
@@ -681,13 +757,13 @@ impl App {
                         } else {
                             Line::from("")
                         })
-                        .padding(Padding::new(0, 0, right[1].height / 2, 0)),
+                        .padding(Padding::new(0, 0, area.height / 2, 0)),
                 )
                 .fg(self.theme.resolve(&self.theme.foreground_dim))
                 .alignment(Alignment::Center)
                 .wrap(Wrap { trim: false });
 
-            frame.render_widget(empty_message, right[1]);
+            frame.render_widget(empty_message, area);
             return;
         }
 
@@ -725,29 +801,7 @@ impl App {
 
         self.state.selected_queue_item = self.state.selected_queue_item.clone().with_offset(offset);
 
-        frame.render_stateful_widget(list, right[1], &mut self.state.selected_queue_item);
-
-        if let Some(download_item) = &self.download_item {
-            let progress = (download_item.progress * 100.0).round() / 100.0;
-            let progress_text = format!("{:.1}%", progress);
-
-            let p = Paragraph::new(format!(
-                "{} {} - {}",
-                &self.spinner_stages[self.spinner], progress_text, &download_item.name,
-            ))
-            .style(Style::default().fg(self.theme.resolve(&self.theme.foreground)))
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(
-                        Line::from("Downloading").fg(self.theme.resolve(&self.theme.section_title)),
-                    )
-                    .border_type(self.border_type)
-                    .fg(self.theme.resolve(&self.theme.border)),
-            );
-
-            frame.render_widget(p, right[2]);
-        }
+        frame.render_stateful_widget(list, area, &mut self.state.selected_queue_item);
     }
 
     fn render_library_center(&mut self, frame: &mut Frame, center: &std::rc::Rc<[Rect]>) {

--- a/src/library.rs
+++ b/src/library.rs
@@ -99,29 +99,16 @@ impl App {
     }
 
     /// Stacked layout used when the Library tab is narrower than
-    /// [`VERTICAL_LAYOUT_THRESHOLD`]. Artists/Albums (25%) on top, Tracks (50%)
-    /// in the middle, Queue (25%) below, an optional download bar, and the
-    /// player bar pinned to the bottom. Lyrics and artwork are intentionally
-    /// omitted here — see follow-up slices.
+    /// [`VERTICAL_LAYOUT_THRESHOLD`]. Mirrors the horizontal layout vertically:
+    /// the (List, Tracks, Lyrics+Queue) width percentages drive the heights of
+    /// the three main sections. Lyrics, when visible, take a fixed 5-row slice
+    /// (3 visible lyric lines + borders), with the rest of the third section
+    /// going to the queue. Player and download strips are pinned at the bottom.
     fn render_home_vertical(&mut self, app_container: Rect, frame: &mut Frame) {
-        // Vertical mode always uses the small-cover sizing, regardless of
-        // `large_art`, so the strip height stays fixed at 8.
-        let player_height = 8;
-        let download_height = if self.download_item.is_some() { 3 } else { 0 };
-
-        let outer = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(vec![
-                Constraint::Percentage(25),
-                Constraint::Percentage(50),
-                Constraint::Percentage(25),
-                Constraint::Min(download_height),
-                Constraint::Length(player_height),
-            ])
-            .split(app_container);
-
+        let outer = self.build_vertical_chunks(app_container);
         let left: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[0]]);
-        let center: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[1], outer[4]]);
+        let center: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[1], outer[5]]);
+        let right: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[2], outer[3], outer[4]]);
 
         match self.state.active_tab {
             ActiveTab::Library => {
@@ -133,12 +120,41 @@ impl App {
             _ => {}
         }
         self.render_library_center(frame, &center);
-        self.render_library_queue(frame, outer[2]);
-        self.render_download_bar(frame, outer[3]);
+        self.render_library_right(frame, right);
         // Vertical mode forces the small-cover sizing regardless of the
         // `large_art` preference, so the player strip height stays fixed.
         self.render_player(frame, &center, false);
         self.create_popup(frame);
+    }
+
+    /// Build the 6-chunk vertical layout shared by Library/Albums/Playlists in
+    /// narrow mode: [list, tracks, lyrics, queue, download, player]. Lyrics is
+    /// fixed at 5 rows (or 0 when hidden), download is 3 or 0, player is 8.
+    /// The remaining space is split between list/tracks/queue using the
+    /// preferred (a, b, c) percentages.
+    pub(crate) fn build_vertical_chunks(&self, app_container: Rect) -> std::rc::Rc<[Rect]> {
+        let player_height = 8;
+        let download_height = if self.download_item.is_some() { 3 } else { 0 };
+        let has_lyrics = self.lyrics.as_ref().is_some_and(|(_, l, _)| !l.is_empty());
+        let show_lyrics_panel = match self.lyrics_visibility {
+            LyricsVisibility::Auto => has_lyrics,
+            LyricsVisibility::Always => true,
+            LyricsVisibility::Never => false,
+        };
+        let lyrics_height = if show_lyrics_panel { 5 } else { 0 };
+        let (a, b, c) = self.preferences.constraint_width_percentages_music;
+
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![
+                Constraint::Fill(a),
+                Constraint::Fill(b),
+                Constraint::Length(lyrics_height),
+                Constraint::Fill(c),
+                Constraint::Length(download_height),
+                Constraint::Length(player_height),
+            ])
+            .split(app_container)
     }
 
     fn render_download_bar(&self, frame: &mut Frame, area: Rect) {
@@ -664,10 +680,7 @@ impl App {
             }
         }
         self.render_library_queue(frame, right[1]);
-
-        if !self.state.queue.is_empty() {
-            self.render_download_bar(frame, right[2]);
-        }
+        self.render_download_bar(frame, right[2]);
     }
 
     pub fn render_library_queue(&mut self, frame: &mut Frame, area: Rect) {

--- a/src/library.rs
+++ b/src/library.rs
@@ -100,11 +100,12 @@ impl App {
 
     /// Stacked layout used when the Library tab is narrower than
     /// [`VERTICAL_LAYOUT_THRESHOLD`]. Artists/Albums (25%) on top, Tracks (50%)
-    /// in the middle, Queue (25%) below, and the player bar pinned to the
-    /// bottom. Lyrics, artwork and the download bar are intentionally omitted
-    /// here — see follow-up slices.
+    /// in the middle, Queue (25%) below, an optional download bar, and the
+    /// player bar pinned to the bottom. Lyrics and artwork are intentionally
+    /// omitted here — see follow-up slices.
     fn render_home_vertical(&mut self, app_container: Rect, frame: &mut Frame) {
         let player_height = if self.preferences.large_art { 7 } else { 8 };
+        let download_height = if self.download_item.is_some() { 3 } else { 0 };
 
         let outer = Layout::default()
             .direction(Direction::Vertical)
@@ -112,12 +113,13 @@ impl App {
                 Constraint::Percentage(25),
                 Constraint::Percentage(50),
                 Constraint::Percentage(25),
+                Constraint::Min(download_height),
                 Constraint::Length(player_height),
             ])
             .split(app_container);
 
         let left: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[0]]);
-        let center: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[1], outer[3]]);
+        let center: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[1], outer[4]]);
 
         match self.state.active_tab {
             ActiveTab::Library => {
@@ -130,8 +132,32 @@ impl App {
         }
         self.render_library_center(frame, &center);
         self.render_library_queue(frame, outer[2]);
+        self.render_download_bar(frame, outer[3]);
         self.render_player(frame, &center);
         self.create_popup(frame);
+    }
+
+    fn render_download_bar(&self, frame: &mut Frame, area: Rect) {
+        let Some(download_item) = &self.download_item else {
+            return;
+        };
+        let progress = (download_item.progress * 100.0).round() / 100.0;
+        let progress_text = format!("{:.1}%", progress);
+
+        let p = Paragraph::new(format!(
+            "{} {} - {}",
+            &self.spinner_stages[self.spinner], progress_text, &download_item.name,
+        ))
+        .style(Style::default().fg(self.theme.resolve(&self.theme.foreground)))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Line::from("Downloading").fg(self.theme.resolve(&self.theme.section_title)))
+                .border_type(self.border_type)
+                .fg(self.theme.resolve(&self.theme.border)),
+        );
+
+        frame.render_widget(p, area);
     }
 
     fn render_library_left(&mut self, frame: &mut Frame, outer_layout: std::rc::Rc<[Rect]>) {

--- a/src/library.rs
+++ b/src/library.rs
@@ -41,9 +41,9 @@ impl App {
         let outer_layout = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(vec![
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.0),
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.1),
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.2),
+                Constraint::Percentage(self.preferences.horizontal_pane_ratios.0),
+                Constraint::Percentage(self.preferences.horizontal_pane_ratios.1),
+                Constraint::Percentage(self.preferences.horizontal_pane_ratios.2),
             ])
             .split(app_container);
 
@@ -99,11 +99,11 @@ impl App {
     }
 
     /// Stacked layout used when the Library tab is narrower than
-    /// [`VERTICAL_LAYOUT_THRESHOLD`]. Mirrors the horizontal layout vertically:
-    /// the (List, Tracks, Lyrics+Queue) width percentages drive the heights of
-    /// the three main sections. Lyrics, when visible, take a fixed 5-row slice
-    /// (3 visible lyric lines + borders), with the rest of the third section
-    /// going to the queue. Player and download strips are pinned at the bottom.
+    /// [`VERTICAL_LAYOUT_THRESHOLD`]. The (List, Tracks, Queue) vertical
+    /// pane ratios drive the heights of the three main sections. Lyrics, when
+    /// visible, take a fixed 5-row slice (3 visible lyric lines + borders),
+    /// between Tracks and Queue. Player and download strips are pinned at the
+    /// bottom.
     fn render_home_vertical(&mut self, app_container: Rect, frame: &mut Frame) {
         let outer = self.build_vertical_chunks(app_container);
         let left: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![outer[0]]);
@@ -142,7 +142,7 @@ impl App {
             LyricsVisibility::Never => false,
         };
         let lyrics_height = if show_lyrics_panel { 5 } else { 0 };
-        let (a, b, c) = self.preferences.constraint_width_percentages_music;
+        let (a, b, c) = self.preferences.vertical_pane_ratios;
 
         Layout::default()
             .direction(Direction::Vertical)

--- a/src/library.rs
+++ b/src/library.rs
@@ -104,7 +104,9 @@ impl App {
     /// player bar pinned to the bottom. Lyrics and artwork are intentionally
     /// omitted here — see follow-up slices.
     fn render_home_vertical(&mut self, app_container: Rect, frame: &mut Frame) {
-        let player_height = if self.preferences.large_art { 7 } else { 8 };
+        // Vertical mode always uses the small-cover sizing, regardless of
+        // `large_art`, so the strip height stays fixed at 8.
+        let player_height = 8;
         let download_height = if self.download_item.is_some() { 3 } else { 0 };
 
         let outer = Layout::default()
@@ -1631,44 +1633,19 @@ impl App {
             .fg(self.theme.resolve(&self.theme.border))
             .padding(Padding::new(0, 0, 0, 0));
 
-        let inner_full = bottom.inner(center[1]);
+        let inner = bottom.inner(center[1]);
         frame.render_widget(bottom, center[1]);
 
-        // In vertical mode with large_art + a loaded cover, render the artwork
-        // on the left of the strip with width derived from the natural aspect
-        // ratio. Player bar takes the remaining width.
-        let vertical_artwork: Option<Rect> = if is_vertical
-            && self.preferences.large_art
-            && self.cover_art.is_some()
-        {
-            let img_area = self
-                .cover_art
-                .as_mut()
-                .unwrap()
-                .size_for(Resize::Scale(None), inner_full);
-            let w = img_area.width.min(inner_full.width);
-            let h = img_area.height.min(inner_full.height);
-            Some(Rect { x: inner_full.x, y: inner_full.y, width: w, height: h })
-        } else {
-            None
-        };
-
-        let inner = if let Some(art) = vertical_artwork {
-            Rect {
-                x: inner_full.x.saturating_add(art.width),
-                y: inner_full.y,
-                width: inner_full.width.saturating_sub(art.width),
-                height: inner_full.height,
-            }
-        } else {
-            inner_full
-        };
+        // Vertical mode renders the cover beside the player bar using the
+        // small-cover variant regardless of `large_art`, so the preference is
+        // only honored in horizontal mode.
+        let large_art = self.preferences.large_art && !is_vertical;
 
         // split the bottom into two parts
         let bottom_split = Layout::default()
             .flex(Flex::SpaceAround)
             .direction(Direction::Horizontal)
-            .constraints(if self.cover_art.is_some() && !self.preferences.large_art {
+            .constraints(if self.cover_art.is_some() && !large_art {
                 vec![
                     Constraint::Percentage(2),
                     Constraint::Length((center[1].height) * 2 + 1),
@@ -1687,7 +1664,7 @@ impl App {
             })
             .split(inner);
 
-        let layout = if self.preferences.large_art {
+        let layout = if large_art {
             Layout::vertical(vec![Constraint::Length(2), Constraint::Length(2)])
         } else {
             Layout::vertical(vec![Constraint::Length(3), Constraint::Length(3)])
@@ -1697,7 +1674,7 @@ impl App {
         let current_track = self.state.queue.get(self.state.current_playback_state.current_index);
         let lines = match current_track {
             Some(song) => {
-                let large = self.cover_art.is_some() && self.preferences.large_art;
+                let large = self.cover_art.is_some() && large_art;
                 let artists = song.artists.join(", ");
 
                 let mut title = vec![
@@ -1748,7 +1725,7 @@ impl App {
             }
         };
 
-        if self.cover_art.is_some() && !self.preferences.large_art {
+        if self.cover_art.is_some() && !large_art {
             let image = StatefulImage::default();
             frame.render_stateful_widget(image, bottom_split[1], self.cover_art.as_mut().unwrap());
         }
@@ -1832,7 +1809,7 @@ impl App {
             Paragraph::new(Line::from(metadata_spans))
                 .centered()
                 .block(Block::bordered().borders(Borders::NONE).padding(Padding::new(0, 0, 1, 0))),
-            if self.preferences.large_art { layout[1] } else { progress_bar_area[0] },
+            if large_art { layout[1] } else { progress_bar_area[0] },
         );
 
         frame.render_widget(
@@ -1843,9 +1820,5 @@ impl App {
             progress_bar_area[1],
         );
 
-        if let Some(art_area) = vertical_artwork {
-            let image = StatefulImage::default().resize(Resize::Scale(None));
-            frame.render_stateful_widget(image, art_area, self.cover_art.as_mut().unwrap());
-        }
     }
 }

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -600,7 +600,7 @@ impl App {
             &self.theme,
         );
 
-        self.render_player(frame, &center);
+        self.render_player(frame, &center, false);
         self.render_library_right(frame, right);
 
         self.create_popup(frame);

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -519,9 +519,9 @@ impl App {
         let outer_layout = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(vec![
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.0),
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.1),
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.2),
+                Constraint::Percentage(self.preferences.horizontal_pane_ratios.0),
+                Constraint::Percentage(self.preferences.horizontal_pane_ratios.1),
+                Constraint::Percentage(self.preferences.horizontal_pane_ratios.2),
             ])
             .split(app_container);
 

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -18,116 +18,21 @@ use ratatui_image::{Resize, StatefulImage};
 impl App {
     pub fn render_playlists(&mut self, app_container: Rect, frame: &mut Frame) {
         let show_lyrics_column = !matches!(self.lyrics_visibility, LyricsVisibility::Never);
+        let is_vertical = app_container.width < crate::library::VERTICAL_LAYOUT_THRESHOLD;
+        // Vertical mode forces the small-cover sizing regardless of the
+        // `large_art` preference, matching the Library tab.
+        let large_art = self.preferences.large_art && !is_vertical;
 
-        let outer_layout = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints(vec![
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.0),
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.1),
-                Constraint::Percentage(self.preferences.constraint_width_percentages_music.2),
-            ])
-            .split(app_container);
-
-        let left = if self.preferences.large_art {
-            if let Some(cover_art) = self.cover_art.as_mut() {
-                let outer_area = outer_layout[0];
-                let block = Block::default()
-                    .borders(Borders::ALL)
-                    .title(
-                        Line::from("Artwork")
-                            .fg(self.theme.resolve(&self.theme.section_title))
-                            .left_aligned(),
-                    )
-                    .fg(self.theme.resolve(&self.theme.section_title))
-                    .border_type(self.border_type)
-                    .border_style(self.theme.resolve(&self.theme.border));
-
-                let chunk_area = block.inner(outer_area);
-                let img_area = cover_art.size_for(Resize::Scale(None), chunk_area);
-
-                let block_total_height = img_area.height + 2;
-                let top_height = outer_area.height.saturating_sub(block_total_height);
-
-                let layout = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints(vec![
-                        Constraint::Length(top_height),         // playlist list area
-                        Constraint::Length(block_total_height), // image area
-                    ])
-                    .split(outer_area);
-
-                frame.render_widget(block, layout[1]);
-
-                let inner_area = layout[1].inner(Margin { vertical: 1, horizontal: 1 });
-                let final_centered = Rect {
-                    x: inner_area.x + (inner_area.width.saturating_sub(img_area.width)) / 2,
-                    y: inner_area.y,
-                    width: img_area.width,
-                    height: img_area.height,
-                };
-
-                let image = StatefulImage::default().resize(Resize::Scale(None));
-                frame.render_stateful_widget(image, final_centered, cover_art);
-
-                layout
-            } else {
-                Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints(vec![Constraint::Percentage(100)])
-                    .split(outer_layout[0])
-            }
-
-            // these two should be the same
+        let (left, center, right) = if is_vertical {
+            let chunks = self.build_vertical_chunks(app_container);
+            let left: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![chunks[0]]);
+            let center: std::rc::Rc<[Rect]> = std::rc::Rc::from(vec![chunks[1], chunks[5]]);
+            let right: std::rc::Rc<[Rect]> =
+                std::rc::Rc::from(vec![chunks[2], chunks[3], chunks[4]]);
+            (left, center, right)
         } else {
-            Layout::default()
-                .direction(Direction::Vertical)
-                .constraints(vec![Constraint::Percentage(100)])
-                .split(outer_layout[0])
+            self.build_playlists_horizontal_chunks(app_container, frame)
         };
-
-        // create a wrapper, to get the width. After that create the inner 'left' and split it
-        let center = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(vec![
-                Constraint::Percentage(100),
-                Constraint::Length(if self.preferences.large_art { 7 } else { 8 }),
-            ])
-            .split(outer_layout[1]);
-
-        let has_lyrics = self.lyrics.as_ref().is_some_and(|(_, l, _)| !l.is_empty());
-
-        let show_panel = match self.lyrics_visibility {
-            LyricsVisibility::Auto => has_lyrics,
-            LyricsVisibility::Always => true,
-            LyricsVisibility::Never => false,
-        };
-
-        let lyrics_slot_constraints = if show_panel {
-            if has_lyrics && !self.lyrics.as_ref().map_or(true, |(_, l, _)| l.len() == 1) {
-                vec![
-                    Constraint::Percentage(68),
-                    Constraint::Percentage(32),
-                    Constraint::Min(if self.download_item.is_some() { 3 } else { 0 }),
-                ]
-            } else {
-                vec![
-                    Constraint::Min(3),
-                    Constraint::Percentage(100),
-                    Constraint::Min(if self.download_item.is_some() { 3 } else { 0 }),
-                ]
-            }
-        } else {
-            vec![
-                Constraint::Min(0),
-                Constraint::Percentage(100),
-                Constraint::Min(if self.download_item.is_some() { 3 } else { 0 }),
-            ]
-        };
-
-        let right = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(lyrics_slot_constraints)
-            .split(outer_layout[2]);
 
         let playlist_block = match self.state.active_section {
             ActiveSection::List => Block::new()
@@ -600,9 +505,124 @@ impl App {
             &self.theme,
         );
 
-        self.render_player(frame, &center, self.preferences.large_art);
+        self.render_player(frame, &center, large_art);
         self.render_library_right(frame, right);
 
         self.create_popup(frame);
+    }
+
+    fn build_playlists_horizontal_chunks(
+        &mut self,
+        app_container: Rect,
+        frame: &mut Frame,
+    ) -> (std::rc::Rc<[Rect]>, std::rc::Rc<[Rect]>, std::rc::Rc<[Rect]>) {
+        let outer_layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![
+                Constraint::Percentage(self.preferences.constraint_width_percentages_music.0),
+                Constraint::Percentage(self.preferences.constraint_width_percentages_music.1),
+                Constraint::Percentage(self.preferences.constraint_width_percentages_music.2),
+            ])
+            .split(app_container);
+
+        let left = if self.preferences.large_art {
+            if let Some(cover_art) = self.cover_art.as_mut() {
+                let outer_area = outer_layout[0];
+                let block = Block::default()
+                    .borders(Borders::ALL)
+                    .title(
+                        Line::from("Artwork")
+                            .fg(self.theme.resolve(&self.theme.section_title))
+                            .left_aligned(),
+                    )
+                    .fg(self.theme.resolve(&self.theme.section_title))
+                    .border_type(self.border_type)
+                    .border_style(self.theme.resolve(&self.theme.border));
+
+                let chunk_area = block.inner(outer_area);
+                let img_area = cover_art.size_for(Resize::Scale(None), chunk_area);
+
+                let block_total_height = img_area.height + 2;
+                let top_height = outer_area.height.saturating_sub(block_total_height);
+
+                let layout = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints(vec![
+                        Constraint::Length(top_height),         // playlist list area
+                        Constraint::Length(block_total_height), // image area
+                    ])
+                    .split(outer_area);
+
+                frame.render_widget(block, layout[1]);
+
+                let inner_area = layout[1].inner(Margin { vertical: 1, horizontal: 1 });
+                let final_centered = Rect {
+                    x: inner_area.x + (inner_area.width.saturating_sub(img_area.width)) / 2,
+                    y: inner_area.y,
+                    width: img_area.width,
+                    height: img_area.height,
+                };
+
+                let image = StatefulImage::default().resize(Resize::Scale(None));
+                frame.render_stateful_widget(image, final_centered, cover_art);
+
+                layout
+            } else {
+                Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints(vec![Constraint::Percentage(100)])
+                    .split(outer_layout[0])
+            }
+        } else {
+            Layout::default()
+                .direction(Direction::Vertical)
+                .constraints(vec![Constraint::Percentage(100)])
+                .split(outer_layout[0])
+        };
+
+        let center = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![
+                Constraint::Percentage(100),
+                Constraint::Length(if self.preferences.large_art { 7 } else { 8 }),
+            ])
+            .split(outer_layout[1]);
+
+        let has_lyrics = self.lyrics.as_ref().is_some_and(|(_, l, _)| !l.is_empty());
+
+        let show_panel = match self.lyrics_visibility {
+            LyricsVisibility::Auto => has_lyrics,
+            LyricsVisibility::Always => true,
+            LyricsVisibility::Never => false,
+        };
+
+        let lyrics_slot_constraints = if show_panel {
+            if has_lyrics && !self.lyrics.as_ref().map_or(true, |(_, l, _)| l.len() == 1) {
+                vec![
+                    Constraint::Percentage(68),
+                    Constraint::Percentage(32),
+                    Constraint::Min(if self.download_item.is_some() { 3 } else { 0 }),
+                ]
+            } else {
+                vec![
+                    Constraint::Min(3),
+                    Constraint::Percentage(100),
+                    Constraint::Min(if self.download_item.is_some() { 3 } else { 0 }),
+                ]
+            }
+        } else {
+            vec![
+                Constraint::Min(0),
+                Constraint::Percentage(100),
+                Constraint::Min(if self.download_item.is_some() { 3 } else { 0 }),
+            ]
+        };
+
+        let right = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(lyrics_slot_constraints)
+            .split(outer_layout[2]);
+
+        (left, center, right)
     }
 }

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -600,7 +600,7 @@ impl App {
             &self.theme,
         );
 
-        self.render_player(frame, &center, false);
+        self.render_player(frame, &center, self.preferences.large_art);
         self.render_library_right(frame, right);
 
         self.create_popup(frame);

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -36,9 +36,16 @@ use url::form_urlencoded;
 
 /// helper function to create a centered rect using up certain percentage of the available rect `r`
 fn popup_area(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
+    popup_area_with_x(area, Constraint::Percentage(percent_x), percent_y)
+}
+
+/// Like [`popup_area`], but the horizontal constraint is caller-supplied so the
+/// popup can be sized in cells instead of percent (used by vertical mode where
+/// 30% of a narrow terminal would truncate menu labels).
+fn popup_area_with_x(area: Rect, x: Constraint, percent_y: u16) -> Rect {
     let vertical =
         Layout::vertical([Constraint::Percentage(percent_y)]).flex(Flex::Start).margin(0);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)]).flex(Flex::Center);
+    let horizontal = Layout::horizontal([x]).flex(Flex::Center);
     let [area] = vertical.areas(area);
     let [area] = horizontal.areas(area);
     area
@@ -3160,7 +3167,14 @@ impl crate::tui::App {
 
             let width = if let PopupMenu::GlobalRunScheduledTask { .. } = menu { 70 } else { 30 };
 
-            let popup_area = popup_area(area, width, percent_height);
+            let popup_area = if area.width < crate::library::VERTICAL_LAYOUT_THRESHOLD {
+                // In vertical mode the terminal is narrow enough that 30% of
+                // its width would truncate menu labels — just use the full
+                // width.
+                popup_area_with_x(area, Constraint::Percentage(100), percent_height)
+            } else {
+                popup_area(area, width, percent_height)
+            };
             frame.render_widget(Clear, popup_area); // clears the background
 
             frame.render_stateful_widget(list, popup_area, &mut self.popup.selected);

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -1472,8 +1472,10 @@ impl crate::tui::App {
                     self.close_popup();
                 }
                 PopupCommand::ResetSectionWidths => {
-                    self.preferences.constraint_width_percentages_music =
-                        crate::helpers::Preferences::default_music_column_widths();
+                    self.preferences.horizontal_pane_ratios =
+                        crate::helpers::Preferences::default_horizontal_pane_ratios();
+                    self.preferences.vertical_pane_ratios =
+                        crate::helpers::Preferences::default_vertical_pane_ratios();
                     if let Err(e) = self.preferences.save() {
                         log::error!("Failed to save preferences: {}", e);
                     }

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -2893,6 +2893,13 @@ impl crate::tui::App {
     }
 
     fn copy_lastfm_album_url(&mut self, track: &DiscographySong) -> Option<()> {
+        if track.album_artist.is_empty() || track.album.is_empty() {
+            self.set_generic_message(
+                "Error copying URL",
+                "This track is missing album or album-artist metadata, so no Last.fm URL can be built.",
+            );
+            return Some(());
+        }
         let url = format!(
             "https://last.fm/music/{}/{}",
             form_urlencoded::byte_serialize(track.album_artist.as_bytes()).collect::<String>(),

--- a/src/search.rs
+++ b/src/search.rs
@@ -77,9 +77,11 @@ impl App {
 
         frame.render_widget(search_term, search_area);
 
-        // split results area into 3 parts
+        // split results area into 3 parts — horizontal when wide, stacked vertically
+        // when narrow, matching the Library/Playlists vertical layout threshold.
+        let is_vertical = results_area.width < crate::library::VERTICAL_LAYOUT_THRESHOLD;
         let results_layout = Layout::default()
-            .direction(Direction::Horizontal)
+            .direction(if is_vertical { Direction::Vertical } else { Direction::Horizontal })
             .constraints(vec![
                 Constraint::Percentage(33),
                 Constraint::Percentage(33),


### PR DESCRIPTION
 ## Summary
Make the TUI responsive so it switch to a stacked view when the widow become to small

<img width="952" height="720" alt="screenrecording-2026-05-23_15-24-34-720p" src="https://github.com/user-attachments/assets/b021f3c6-ba72-4f05-9f60-d93fbc93e2e8" />

  - Adds a vertical layout that activates on narrow terminals
  - Artwork rendered beside the player bar; small cover always shown
  - Download bar and full-width context popup adapted to the new layout

> Part of that code as been generated with AI
>
> Also, sorry I forgot to create an issue first... 
> Hope you approve the feature. Thanks for your work !