### PR TITLE
Fix update spam

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -9,26 +9,18 @@ Notable fields:
 -------------------------- */
 use crate::client::{
     Album, Artist, AuthMethod, Client, DiscographySong, LibraryView, Lyric, NetworkQuality,
-    Playlist, ProgressReport, ProgressReportInternal, QueueItem, RemoteCommand,
-    TempDiscographyAlbum, Transcoding,
+    Playlist, ProgressReport, TempDiscographyAlbum, Transcoding,
 };
 use crate::config::LyricsVisibility;
 use crate::database;
-use crate::database::database::{
-    Command, DownloadCommand, DownloadItem, JellyfinCommand, UpdateCommand,
-};
 use crate::database::extension::{
     get_album_tracks, get_albums_with_tracks, get_all_albums, get_all_artists, get_all_playlists,
     get_artists_with_tracks, get_discography, get_libraries, get_lyrics, get_playlist_tracks,
     get_playlists_with_tracks, insert_lyrics,
 };
-use crate::help::{build_tab_labels, render_help_modal};
-use crate::helpers::{Preferences, State, Symbols};
+use crate::helpers::{Preferences, State};
 use crate::keyboard::{try_load_keymap, ActiveSection, ActiveTab, Selectable};
-use crate::mpv::MpvHandle;
 use crate::popup::PopupState;
-use crate::themes::dialoguer::DialogTheme;
-use crate::themes::theme::Theme;
 use crate::{helpers, mpris, sort};
 
 /// A type alias for the terminal type used in this application
@@ -60,6 +52,13 @@ use std::sync::Arc;
 
 use crokey::{Combiner, KeyCombination};
 
+use crate::database::database::{
+    Command, DownloadCommand, DownloadItem, JellyfinCommand, UpdateCommand,
+};
+use crate::help::render_help_modal;
+use crate::mpv::MpvHandle;
+use crate::themes::dialoguer::DialogTheme;
+use crate::themes::theme::Theme;
 use dialoguer::Select;
 use discord_rich_presence::activity::StatusDisplayType;
 use indexmap::IndexMap;
@@ -210,7 +209,6 @@ pub struct App {
     pub keymap: IndexMap<KeyCombination, crate::keyboard::Action>,
     pub keymap_error: Option<String>,
     pub combiner: Combiner,
-    tab_labels: [String; 4],
     config_watcher: crate::themes::theme::ConfigWatcher,
     pub auto_color: bool, // grab color from cover art (coolest feature ever omg)
     pub border_type: BorderType,
@@ -244,9 +242,8 @@ pub struct App {
     pub buffering: bool,               // buffering state (spinner)
     pub download_item: Option<DownloadItem>,
 
-    pub symbols: Symbols,
     pub spinner: usize, // spinner for buffering
-    pub spinner_stages: Vec<String>,
+    pub spinner_stages: Vec<&'static str>,
     last_spinner_tick: Instant,
 
     pub searching: bool,
@@ -276,7 +273,6 @@ pub struct App {
     pub popup_search_term: String, // this is here because popup isn't persisted
 
     pub client: Option<Arc<Client>>, // jellyfin http client
-    pub client_ws_rx: Option<tokio::sync::mpsc::Receiver<RemoteCommand>>,
     pub network_quality: NetworkQuality,
     pub discord:
         Option<(mpsc::Sender<crate::discord::DiscordCommand>, Instant, bool, StatusDisplayType)>, // discord presence tx
@@ -300,6 +296,7 @@ pub struct App {
     pub last_meta_update: Instant,
     pub recent_input_activity: Instant,
     last_state_saved: Instant,
+    last_position_secs: f64,
     scrobble_this: (String, u64), // an id of the previous song we want to scrobble when it ends, and the position in jellyfin ticks
     should_scrobble: bool,        // flag to track if we should scrobble the current song
     pub controls: Option<MediaControls>,
@@ -328,15 +325,11 @@ impl App {
                 keymap
             }
             Err(err) => {
-                log::error!("Failed to parse keymap: {}", err);
-                if err.to_string().contains("VolumeUp") || err.to_string().contains("VolumeDown") {
-                    eprintln!(" ! VolumeUp and VolumeDown actions have been replaced by the !Volume delta action. Please update your keymap. \"VolumeDown\" -> \"!Volume -5\"");
-                }
                 eprintln!(" ! Failed to parse keymap: {}", err);
+                log::error!("Failed to parse keymap: {}", err);
                 std::process::exit(1);
             }
         };
-        let tab_labels = build_tab_labels(&keymap);
 
         let (sender, receiver) = channel();
         let (cmd_tx, cmd_rx) = mpsc::channel::<database::database::Command>(64);
@@ -344,25 +337,23 @@ impl App {
         let (mpris_tx, mpris_rx) = channel::<MediaControlEvent>();
 
         // try to go online, construct the http client
-        let (client, network_quality, client_ws_rx, successfully_online) = if !offline {
-            // websocket init
-            let (ws_tx, ws_rx) = tokio::sync::mpsc::channel(64);
-
-            match App::init_online(&config, force_server_select, ws_tx).await {
-                Some((client, network_quality)) => {
-                    let ws_client = Arc::clone(&client);
-
-                    tokio::spawn(async move {
-                        ws_client.run_remote_socket().await;
-                    });
-
-                    (Some(client), network_quality, Some(ws_rx), true)
+        let mut client: Option<Arc<Client>> = None;
+        let mut network_quality = NetworkQuality::Normal;
+        let successfully_online = if !offline {
+            match App::init_online(&config, force_server_select).await {
+                Some((c, n_quality)) => {
+                    client = Some(c);
+                    network_quality = n_quality;
+                    true
                 }
-                None => (None, NetworkQuality::Normal, None, false),
+                None => false,
             }
         } else {
-            (None, NetworkQuality::Normal, None, false)
+            false
         };
+        // if !successfully_online && !offline {
+        //     println!(" ! Connection failed. Running in offline mode.")
+        // }
 
         // db init
         let (db_path, server_id) = Self::get_database_file(&config, &client);
@@ -446,11 +437,6 @@ impl App {
             None
         };
 
-        let symbols: Symbols = config
-            .get("symbols")
-            .and_then(|v| serde_yaml::from_value(v.clone()).ok())
-            .unwrap_or_default();
-
         let default_title_fmt = r#"{title} – {artist} ({year})"#;
         let (window_title_enabled, window_title_format) = match config.get("window_title") {
             Some(v) if v.is_bool() => {
@@ -492,7 +478,6 @@ impl App {
             keymap,
             keymap_error: None,
             combiner: Combiner::default(),
-            tab_labels,
             config_watcher,
             auto_color,
             border_type: match config.get("rounded_corners").and_then(|b| b.as_bool()) {
@@ -543,9 +528,8 @@ impl App {
             buffering: false,
             download_item: None,
 
-            spinner_stages: symbols.spinner_stages(),
-            symbols,
             spinner: 0,
+            spinner_stages: vec!["◰", "◳", "◲", "◱"],
             last_spinner_tick: Instant::now(),
 
             searching: false,
@@ -574,7 +558,6 @@ impl App {
             popup_search_term: String::from(""),
 
             client,
-            client_ws_rx,
             network_quality,
             discord,
             downloads_dir: data_dir().unwrap().join("jellyfin-tui").join("downloads"),
@@ -594,6 +577,7 @@ impl App {
             recent_input_activity: Instant::now(),
             last_state_saved: Instant::now(),
 
+            last_position_secs: 0.0,
             scrobble_this: (String::from(""), 0),
             should_scrobble: false,
             controls,
@@ -612,7 +596,6 @@ impl App {
     async fn init_online(
         config: &serde_yaml::Value,
         force_server_select: bool,
-        ws_tx: tokio::sync::mpsc::Sender<RemoteCommand>,
     ) -> Option<(Arc<Client>, NetworkQuality)> {
         let selected_server = crate::config::select_server(config, force_server_select)?;
         let mut auth_cache = crate::config::load_auth_cache().unwrap_or_default();
@@ -623,9 +606,7 @@ impl App {
             Client::probe_server(&reqwest::Client::new(), &selected_server.url).await;
 
         if let Some((server_id, cached_entry)) = maybe_cached {
-            let client =
-                Client::from_cache(&selected_server.url, server_id, cached_entry, ws_tx.clone())
-                    .await;
+            let client = Client::from_cache(&selected_server.url, server_id, cached_entry).await;
             if client.validate_token().await {
                 return Some((client, network_quality));
             }
@@ -633,9 +614,9 @@ impl App {
         }
         let client = match &selected_server.auth {
             AuthMethod::UserPass { username, password } => {
-                Client::new(&base_url, username, password, ws_tx).await?
+                Client::new(&base_url, username, password).await?
             }
-            AuthMethod::QuickConnect => Client::quick_connect(&base_url, ws_tx).await,
+            AuthMethod::QuickConnect => Client::quick_connect(&base_url).await,
         };
         if client.access_token.is_empty() {
             println!(" ! Failed to authenticate. Please check your credentials and try again.");
@@ -1138,7 +1119,7 @@ impl App {
             .cloned()
             .unwrap_or_default();
 
-        self.report_progress_if_needed().await?;
+        self.report_progress_if_needed(false).await?;
         self.handle_lyrics_scroll().await;
         self.handle_scrobble(&current_song).await?;
         self.handle_song_change(&current_song).await?;
@@ -1153,8 +1134,6 @@ impl App {
         self.handle_sleep_timer().await;
 
         self.handle_state_autosave();
-
-        self.handle_remote_commands().await;
 
         // update spinners (all are the same)
         let now = Instant::now();
@@ -1196,16 +1175,10 @@ impl App {
                     .and_then(|v| v.as_str())
                     .map(LyricsVisibility::from_config)
                     .unwrap_or(LyricsVisibility::Always);
-                self.symbols = new_config
-                    .get("symbols")
-                    .and_then(|v| serde_yaml::from_value(v.clone()).ok())
-                    .unwrap_or_default();
-                self.spinner_stages = self.symbols.spinner_stages();
 
                 match try_load_keymap(&new_config) {
                     Ok(keymap) => {
                         self.keymap = keymap;
-                        self.tab_labels = build_tab_labels(&self.keymap);
                         self.keymap_error = None;
                     }
                     Err(err) => {
@@ -1239,11 +1212,23 @@ impl App {
     }
 
     async fn update_playback_state(&mut self, state: &MpvPlaybackState) {
-        self.dirty = true;
         let playback = &mut self.state.current_playback_state;
 
         let old_position = playback.position;
         let new_position = state.position;
+
+        // Check for state updates to see if we need to redraw
+        if old_position != new_position {
+            self.dirty = true;
+        }
+
+        if playback.volume != state.volume {
+            self.dirty = true;
+        }
+
+        if playback.duration != state.duration {
+            self.dirty = true;
+        }
 
         playback.position = new_position;
         playback.current_index = state.current_index;
@@ -1351,28 +1336,24 @@ impl App {
         }
     }
 
-    pub async fn report_progress_if_needed(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn report_progress_if_needed(
+        &mut self,
+        force: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let Some(current_song) =
+            self.state.queue.get(self.state.current_playback_state.current_index)
+        else {
+            return Ok(());
+        };
+
         let playback = &self.state.current_playback_state;
 
-        let current = ProgressReportInternal {
-            position: playback.position,
-            paused: self.paused,
-            volume: playback.volume,
-            current_index: playback.current_index,
-        };
+        if (self.last_position_secs + 10.0) < playback.position || force {
+            self.last_position_secs = playback.position;
 
-        let should_report = match &self.state.last_reported {
-            None => true,
-            Some(prev) => {
-                (current.position - prev.position).abs() >= 5.0
-                    || current.paused != prev.paused
-                    || (current.volume - prev.volume).abs() >= 1
-                    || current.current_index != prev.current_index
-            }
-        };
-
-        if should_report {
-            self.state.last_reported = Some(current);
+            // every 5 seconds report progress to jellyfin
+            self.scrobble_this =
+                (current_song.id.clone(), (playback.position * 10_000_000.0) as u64);
 
             if self.client.is_some() {
                 let _ = self
@@ -1381,40 +1362,19 @@ impl App {
                     .send(Command::Jellyfin(JellyfinCommand::ReportProgress {
                         progress_report: ProgressReport {
                             volume_level: playback.volume as u64,
-                            play_method: if self.transcoding.enabled {
-                                "Transcode"
-                            } else {
-                                "DirectPlay"
-                            }
-                            .into(),
-                            playback_order: if self.state.shuffle { "Shuffle" } else { "Default" }
-                                .into(),
-                            repeat_mode: match self.preferences.repeat {
-                                Repeat::None => "RepeatNone",
-                                Repeat::One => "RepeatOne",
-                                Repeat::All => "RepeatAll",
-                                _ => "RepeatAll",
-                            }
-                            .into(),
                             is_paused: self.paused,
-                            is_muted: false,
-                            position_ticks: (playback.position * 10_000_000.0) as u64,
+                            position_ticks: self.scrobble_this.1,
                             media_source_id: self.active_song_id.clone(),
                             playback_start_time_ticks: 0,
-                            can_seek: true,
+                            can_seek: false,
                             item_id: self.active_song_id.clone(),
                             event_name: "timeupdate".into(),
-                            now_playing_queue: self
-                                .state
-                                .queue
-                                .iter()
-                                .skip(playback.current_index)
-                                .map(|s| QueueItem { id: s.id.clone(), playlist_item_id: None })
-                                .collect(),
                         },
                     }))
                     .await;
             }
+        } else if self.last_position_secs > playback.position {
+            self.last_position_secs = playback.position;
         }
 
         Ok(())
@@ -1477,42 +1437,7 @@ impl App {
             let _ = self
                 .db
                 .cmd_tx
-                .send(Command::Jellyfin(JellyfinCommand::Playing {
-                    progress_report: ProgressReport {
-                        volume_level: self.state.current_playback_state.volume as u64,
-                        play_method: if self.transcoding.enabled {
-                            "Transcode"
-                        } else {
-                            "DirectPlay"
-                        }
-                        .into(),
-                        playback_order: if self.state.shuffle { "Shuffle" } else { "Default" }
-                            .into(),
-                        repeat_mode: match self.preferences.repeat {
-                            Repeat::None => "RepeatNone",
-                            Repeat::One => "RepeatOne",
-                            Repeat::All => "RepeatAll",
-                            _ => "RepeatAll",
-                        }
-                        .into(),
-                        is_paused: self.paused,
-                        is_muted: false,
-                        position_ticks: (self.state.current_playback_state.position * 10_000_000.0)
-                            as u64,
-                        media_source_id: song.id.clone(),
-                        playback_start_time_ticks: 0,
-                        can_seek: true,
-                        item_id: song.id.clone(),
-                        event_name: "timeupdate".into(),
-                        now_playing_queue: self
-                            .state
-                            .queue
-                            .iter()
-                            .skip(self.state.current_playback_state.current_index)
-                            .map(|s| QueueItem { id: s.id.clone(), playlist_item_id: None })
-                            .collect(),
-                    },
-                }))
+                .send(Command::Jellyfin(JellyfinCommand::Playing { id: song.id.clone() }))
                 .await;
         }
 
@@ -1622,7 +1547,6 @@ impl App {
 
         Ok(())
     }
-
     async fn handle_sleep_timer(&mut self) {
         let Some(timer) = self.sleep_timer else {
             return;
@@ -1632,25 +1556,24 @@ impl App {
             SleepTimer::At(deadline) => {
                 let now = Instant::now();
 
+                let base = *self
+                    .sleep_timer_original_volume
+                    .get_or_insert(self.state.current_playback_state.volume);
+
                 if now >= deadline {
                     self.pause().await;
 
-                    if let Some(base) = self.sleep_timer_original_volume.take() {
-                        self.mpv_handle.set_volume(base).await;
-                        self.state.current_playback_state.volume = base;
-                    }
+                    self.mpv_handle.set_volume(base).await;
+                    self.state.current_playback_state.volume = base;
 
                     self.sleep_timer = None;
+                    self.sleep_timer_original_volume = None;
                     return;
                 }
 
                 let remaining = deadline.saturating_duration_since(now).as_secs_f64();
 
                 if remaining <= SLEEP_TIMER_FADE_SECS {
-                    let base = *self
-                        .sleep_timer_original_volume
-                        .get_or_insert(self.state.current_playback_state.volume);
-
                     let factor = (remaining / SLEEP_TIMER_FADE_SECS).clamp(0.0, 1.0);
                     let volume = (base as f64 * factor).round() as i64;
 
@@ -1930,13 +1853,13 @@ impl App {
             ])
             .split(area);
 
-        Tabs::new(self.tab_labels.to_vec())
+        Tabs::new(vec!["Library", "Albums", "Playlists", "Search"])
             .style(Style::default().fg(self.theme.resolve(&self.theme.tab_inactive_foreground)))
             .highlight_style(
                 Style::default().fg(self.theme.resolve(&self.theme.tab_active_foreground)),
             )
             .select(self.state.active_tab as usize)
-            .divider(&self.symbols.separator)
+            .divider("•")
             .padding(" ", " ")
             .render(tabs_layout[0], buf);
 
@@ -1994,10 +1917,6 @@ impl App {
             };
 
             status_bar.push(Span::raw(label).fg(color).bold());
-        }
-
-        if self.state.shuffle {
-            status_bar.push(Span::raw("⤮ shuffle").fg(self.theme.resolve(&self.theme.foreground)));
         }
 
         if self.transcoding.enabled {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -9,18 +9,26 @@ Notable fields:
 -------------------------- */
 use crate::client::{
     Album, Artist, AuthMethod, Client, DiscographySong, LibraryView, Lyric, NetworkQuality,
-    Playlist, ProgressReport, TempDiscographyAlbum, Transcoding,
+    Playlist, ProgressReport, ProgressReportInternal, QueueItem, RemoteCommand,
+    TempDiscographyAlbum, Transcoding,
 };
 use crate::config::LyricsVisibility;
 use crate::database;
+use crate::database::database::{
+    Command, DownloadCommand, DownloadItem, JellyfinCommand, UpdateCommand,
+};
 use crate::database::extension::{
     get_album_tracks, get_albums_with_tracks, get_all_albums, get_all_artists, get_all_playlists,
     get_artists_with_tracks, get_discography, get_libraries, get_lyrics, get_playlist_tracks,
     get_playlists_with_tracks, insert_lyrics,
 };
-use crate::helpers::{Preferences, State};
+use crate::help::{build_tab_labels, render_help_modal};
+use crate::helpers::{Preferences, State, Symbols};
 use crate::keyboard::{try_load_keymap, ActiveSection, ActiveTab, Selectable};
+use crate::mpv::MpvHandle;
 use crate::popup::PopupState;
+use crate::themes::dialoguer::DialogTheme;
+use crate::themes::theme::Theme;
 use crate::{helpers, mpris, sort};
 
 /// A type alias for the terminal type used in this application
@@ -52,13 +60,6 @@ use std::sync::Arc;
 
 use crokey::{Combiner, KeyCombination};
 
-use crate::database::database::{
-    Command, DownloadCommand, DownloadItem, JellyfinCommand, UpdateCommand,
-};
-use crate::help::render_help_modal;
-use crate::mpv::MpvHandle;
-use crate::themes::dialoguer::DialogTheme;
-use crate::themes::theme::Theme;
 use dialoguer::Select;
 use discord_rich_presence::activity::StatusDisplayType;
 use indexmap::IndexMap;
@@ -209,6 +210,7 @@ pub struct App {
     pub keymap: IndexMap<KeyCombination, crate::keyboard::Action>,
     pub keymap_error: Option<String>,
     pub combiner: Combiner,
+    tab_labels: [String; 4],
     config_watcher: crate::themes::theme::ConfigWatcher,
     pub auto_color: bool, // grab color from cover art (coolest feature ever omg)
     pub border_type: BorderType,
@@ -242,8 +244,9 @@ pub struct App {
     pub buffering: bool,               // buffering state (spinner)
     pub download_item: Option<DownloadItem>,
 
+    pub symbols: Symbols,
     pub spinner: usize, // spinner for buffering
-    pub spinner_stages: Vec<&'static str>,
+    pub spinner_stages: Vec<String>,
     last_spinner_tick: Instant,
 
     pub searching: bool,
@@ -273,6 +276,7 @@ pub struct App {
     pub popup_search_term: String, // this is here because popup isn't persisted
 
     pub client: Option<Arc<Client>>, // jellyfin http client
+    pub client_ws_rx: Option<tokio::sync::mpsc::Receiver<RemoteCommand>>,
     pub network_quality: NetworkQuality,
     pub discord:
         Option<(mpsc::Sender<crate::discord::DiscordCommand>, Instant, bool, StatusDisplayType)>, // discord presence tx
@@ -296,7 +300,6 @@ pub struct App {
     pub last_meta_update: Instant,
     pub recent_input_activity: Instant,
     last_state_saved: Instant,
-    last_position_secs: f64,
     scrobble_this: (String, u64), // an id of the previous song we want to scrobble when it ends, and the position in jellyfin ticks
     should_scrobble: bool,        // flag to track if we should scrobble the current song
     pub controls: Option<MediaControls>,
@@ -325,11 +328,15 @@ impl App {
                 keymap
             }
             Err(err) => {
-                eprintln!(" ! Failed to parse keymap: {}", err);
                 log::error!("Failed to parse keymap: {}", err);
+                if err.to_string().contains("VolumeUp") || err.to_string().contains("VolumeDown") {
+                    eprintln!(" ! VolumeUp and VolumeDown actions have been replaced by the !Volume delta action. Please update your keymap. \"VolumeDown\" -> \"!Volume -5\"");
+                }
+                eprintln!(" ! Failed to parse keymap: {}", err);
                 std::process::exit(1);
             }
         };
+        let tab_labels = build_tab_labels(&keymap);
 
         let (sender, receiver) = channel();
         let (cmd_tx, cmd_rx) = mpsc::channel::<database::database::Command>(64);
@@ -337,23 +344,25 @@ impl App {
         let (mpris_tx, mpris_rx) = channel::<MediaControlEvent>();
 
         // try to go online, construct the http client
-        let mut client: Option<Arc<Client>> = None;
-        let mut network_quality = NetworkQuality::Normal;
-        let successfully_online = if !offline {
-            match App::init_online(&config, force_server_select).await {
-                Some((c, n_quality)) => {
-                    client = Some(c);
-                    network_quality = n_quality;
-                    true
+        let (client, network_quality, client_ws_rx, successfully_online) = if !offline {
+            // websocket init
+            let (ws_tx, ws_rx) = tokio::sync::mpsc::channel(64);
+
+            match App::init_online(&config, force_server_select, ws_tx).await {
+                Some((client, network_quality)) => {
+                    let ws_client = Arc::clone(&client);
+
+                    tokio::spawn(async move {
+                        ws_client.run_remote_socket().await;
+                    });
+
+                    (Some(client), network_quality, Some(ws_rx), true)
                 }
-                None => false,
+                None => (None, NetworkQuality::Normal, None, false),
             }
         } else {
-            false
+            (None, NetworkQuality::Normal, None, false)
         };
-        // if !successfully_online && !offline {
-        //     println!(" ! Connection failed. Running in offline mode.")
-        // }
 
         // db init
         let (db_path, server_id) = Self::get_database_file(&config, &client);
@@ -437,6 +446,11 @@ impl App {
             None
         };
 
+        let symbols: Symbols = config
+            .get("symbols")
+            .and_then(|v| serde_yaml::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
         let default_title_fmt = r#"{title} – {artist} ({year})"#;
         let (window_title_enabled, window_title_format) = match config.get("window_title") {
             Some(v) if v.is_bool() => {
@@ -478,6 +492,7 @@ impl App {
             keymap,
             keymap_error: None,
             combiner: Combiner::default(),
+            tab_labels,
             config_watcher,
             auto_color,
             border_type: match config.get("rounded_corners").and_then(|b| b.as_bool()) {
@@ -528,8 +543,9 @@ impl App {
             buffering: false,
             download_item: None,
 
+            spinner_stages: symbols.spinner_stages(),
+            symbols,
             spinner: 0,
-            spinner_stages: vec!["◰", "◳", "◲", "◱"],
             last_spinner_tick: Instant::now(),
 
             searching: false,
@@ -558,6 +574,7 @@ impl App {
             popup_search_term: String::from(""),
 
             client,
+            client_ws_rx,
             network_quality,
             discord,
             downloads_dir: data_dir().unwrap().join("jellyfin-tui").join("downloads"),
@@ -577,7 +594,6 @@ impl App {
             recent_input_activity: Instant::now(),
             last_state_saved: Instant::now(),
 
-            last_position_secs: 0.0,
             scrobble_this: (String::from(""), 0),
             should_scrobble: false,
             controls,
@@ -596,6 +612,7 @@ impl App {
     async fn init_online(
         config: &serde_yaml::Value,
         force_server_select: bool,
+        ws_tx: tokio::sync::mpsc::Sender<RemoteCommand>,
     ) -> Option<(Arc<Client>, NetworkQuality)> {
         let selected_server = crate::config::select_server(config, force_server_select)?;
         let mut auth_cache = crate::config::load_auth_cache().unwrap_or_default();
@@ -606,7 +623,9 @@ impl App {
             Client::probe_server(&reqwest::Client::new(), &selected_server.url).await;
 
         if let Some((server_id, cached_entry)) = maybe_cached {
-            let client = Client::from_cache(&selected_server.url, server_id, cached_entry).await;
+            let client =
+                Client::from_cache(&selected_server.url, server_id, cached_entry, ws_tx.clone())
+                    .await;
             if client.validate_token().await {
                 return Some((client, network_quality));
             }
@@ -614,9 +633,9 @@ impl App {
         }
         let client = match &selected_server.auth {
             AuthMethod::UserPass { username, password } => {
-                Client::new(&base_url, username, password).await?
+                Client::new(&base_url, username, password, ws_tx).await?
             }
-            AuthMethod::QuickConnect => Client::quick_connect(&base_url).await,
+            AuthMethod::QuickConnect => Client::quick_connect(&base_url, ws_tx).await,
         };
         if client.access_token.is_empty() {
             println!(" ! Failed to authenticate. Please check your credentials and try again.");
@@ -1119,7 +1138,7 @@ impl App {
             .cloned()
             .unwrap_or_default();
 
-        self.report_progress_if_needed(false).await?;
+        self.report_progress_if_needed().await?;
         self.handle_lyrics_scroll().await;
         self.handle_scrobble(&current_song).await?;
         self.handle_song_change(&current_song).await?;
@@ -1134,6 +1153,8 @@ impl App {
         self.handle_sleep_timer().await;
 
         self.handle_state_autosave();
+
+        self.handle_remote_commands().await;
 
         // update spinners (all are the same)
         let now = Instant::now();
@@ -1175,10 +1196,16 @@ impl App {
                     .and_then(|v| v.as_str())
                     .map(LyricsVisibility::from_config)
                     .unwrap_or(LyricsVisibility::Always);
+                self.symbols = new_config
+                    .get("symbols")
+                    .and_then(|v| serde_yaml::from_value(v.clone()).ok())
+                    .unwrap_or_default();
+                self.spinner_stages = self.symbols.spinner_stages();
 
                 match try_load_keymap(&new_config) {
                     Ok(keymap) => {
                         self.keymap = keymap;
+                        self.tab_labels = build_tab_labels(&self.keymap);
                         self.keymap_error = None;
                     }
                     Err(err) => {
@@ -1336,24 +1363,28 @@ impl App {
         }
     }
 
-    pub async fn report_progress_if_needed(
-        &mut self,
-        force: bool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let Some(current_song) =
-            self.state.queue.get(self.state.current_playback_state.current_index)
-        else {
-            return Ok(());
-        };
-
+    pub async fn report_progress_if_needed(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let playback = &self.state.current_playback_state;
 
-        if (self.last_position_secs + 10.0) < playback.position || force {
-            self.last_position_secs = playback.position;
+        let current = ProgressReportInternal {
+            position: playback.position,
+            paused: self.paused,
+            volume: playback.volume,
+            current_index: playback.current_index,
+        };
 
-            // every 5 seconds report progress to jellyfin
-            self.scrobble_this =
-                (current_song.id.clone(), (playback.position * 10_000_000.0) as u64);
+        let should_report = match &self.state.last_reported {
+            None => true,
+            Some(prev) => {
+                (current.position - prev.position).abs() >= 5.0
+                    || current.paused != prev.paused
+                    || (current.volume - prev.volume).abs() >= 1
+                    || current.current_index != prev.current_index
+            }
+        };
+
+        if should_report {
+            self.state.last_reported = Some(current);
 
             if self.client.is_some() {
                 let _ = self
@@ -1362,19 +1393,40 @@ impl App {
                     .send(Command::Jellyfin(JellyfinCommand::ReportProgress {
                         progress_report: ProgressReport {
                             volume_level: playback.volume as u64,
+                            play_method: if self.transcoding.enabled {
+                                "Transcode"
+                            } else {
+                                "DirectPlay"
+                            }
+                            .into(),
+                            playback_order: if self.state.shuffle { "Shuffle" } else { "Default" }
+                                .into(),
+                            repeat_mode: match self.preferences.repeat {
+                                Repeat::None => "RepeatNone",
+                                Repeat::One => "RepeatOne",
+                                Repeat::All => "RepeatAll",
+                                _ => "RepeatAll",
+                            }
+                            .into(),
                             is_paused: self.paused,
-                            position_ticks: self.scrobble_this.1,
+                            is_muted: false,
+                            position_ticks: (playback.position * 10_000_000.0) as u64,
                             media_source_id: self.active_song_id.clone(),
                             playback_start_time_ticks: 0,
-                            can_seek: false,
+                            can_seek: true,
                             item_id: self.active_song_id.clone(),
                             event_name: "timeupdate".into(),
+                            now_playing_queue: self
+                                .state
+                                .queue
+                                .iter()
+                                .skip(playback.current_index)
+                                .map(|s| QueueItem { id: s.id.clone(), playlist_item_id: None })
+                                .collect(),
                         },
                     }))
                     .await;
             }
-        } else if self.last_position_secs > playback.position {
-            self.last_position_secs = playback.position;
         }
 
         Ok(())
@@ -1437,7 +1489,42 @@ impl App {
             let _ = self
                 .db
                 .cmd_tx
-                .send(Command::Jellyfin(JellyfinCommand::Playing { id: song.id.clone() }))
+                .send(Command::Jellyfin(JellyfinCommand::Playing {
+                    progress_report: ProgressReport {
+                        volume_level: self.state.current_playback_state.volume as u64,
+                        play_method: if self.transcoding.enabled {
+                            "Transcode"
+                        } else {
+                            "DirectPlay"
+                        }
+                        .into(),
+                        playback_order: if self.state.shuffle { "Shuffle" } else { "Default" }
+                            .into(),
+                        repeat_mode: match self.preferences.repeat {
+                            Repeat::None => "RepeatNone",
+                            Repeat::One => "RepeatOne",
+                            Repeat::All => "RepeatAll",
+                            _ => "RepeatAll",
+                        }
+                        .into(),
+                        is_paused: self.paused,
+                        is_muted: false,
+                        position_ticks: (self.state.current_playback_state.position * 10_000_000.0)
+                            as u64,
+                        media_source_id: song.id.clone(),
+                        playback_start_time_ticks: 0,
+                        can_seek: true,
+                        item_id: song.id.clone(),
+                        event_name: "timeupdate".into(),
+                        now_playing_queue: self
+                            .state
+                            .queue
+                            .iter()
+                            .skip(self.state.current_playback_state.current_index)
+                            .map(|s| QueueItem { id: s.id.clone(), playlist_item_id: None })
+                            .collect(),
+                    },
+                }))
                 .await;
         }
 
@@ -1547,6 +1634,7 @@ impl App {
 
         Ok(())
     }
+
     async fn handle_sleep_timer(&mut self) {
         let Some(timer) = self.sleep_timer else {
             return;
@@ -1556,24 +1644,25 @@ impl App {
             SleepTimer::At(deadline) => {
                 let now = Instant::now();
 
-                let base = *self
-                    .sleep_timer_original_volume
-                    .get_or_insert(self.state.current_playback_state.volume);
-
                 if now >= deadline {
                     self.pause().await;
 
-                    self.mpv_handle.set_volume(base).await;
-                    self.state.current_playback_state.volume = base;
+                    if let Some(base) = self.sleep_timer_original_volume.take() {
+                        self.mpv_handle.set_volume(base).await;
+                        self.state.current_playback_state.volume = base;
+                    }
 
                     self.sleep_timer = None;
-                    self.sleep_timer_original_volume = None;
                     return;
                 }
 
                 let remaining = deadline.saturating_duration_since(now).as_secs_f64();
 
                 if remaining <= SLEEP_TIMER_FADE_SECS {
+                    let base = *self
+                        .sleep_timer_original_volume
+                        .get_or_insert(self.state.current_playback_state.volume);
+
                     let factor = (remaining / SLEEP_TIMER_FADE_SECS).clamp(0.0, 1.0);
                     let volume = (base as f64 * factor).round() as i64;
 
@@ -1853,13 +1942,13 @@ impl App {
             ])
             .split(area);
 
-        Tabs::new(vec!["Library", "Albums", "Playlists", "Search"])
+        Tabs::new(self.tab_labels.to_vec())
             .style(Style::default().fg(self.theme.resolve(&self.theme.tab_inactive_foreground)))
             .highlight_style(
                 Style::default().fg(self.theme.resolve(&self.theme.tab_active_foreground)),
             )
             .select(self.state.active_tab as usize)
-            .divider("•")
+            .divider(&self.symbols.separator)
             .padding(" ", " ")
             .render(tabs_layout[0], buf);
 
@@ -1917,6 +2006,10 @@ impl App {
             };
 
             status_bar.push(Span::raw(label).fg(color).bold());
+        }
+
+        if self.state.shuffle {
+            status_bar.push(Span::raw("⤮ shuffle").fg(self.theme.resolve(&self.theme.foreground)));
         }
 
         if self.transcoding.enabled {


### PR DESCRIPTION
Hi!

I noticed that on my RK3399 machine the UI would lock up while a song was playing or paused. I saw the previous PRs and agree that rate limiting updates is not the way to go. I tracked the spurious dirty requests to update_playback_state. That function sets dirty unconditionally, so I changed it to only set dirty if the new state is different from the current state. In my testing that brought CPU usage down to about 5% while playing. I may not have covered enough state changes with my conditions, happy to discuss that part. 