### PR TITLE
Implement basic search for keymaps

### DIFF
--- a/src/help.rs
+++ b/src/help.rs
@@ -1,6 +1,6 @@
 use ratatui::{prelude::*, widgets::*, Frame};
 
-use crate::helpers::centered_rect_percent;
+use crate::helpers::{centered_rect_percent, find_all_subsequences, normalize_for_search};
 use crate::keyboard::{Action, ActionCategory};
 use crate::themes::theme::Theme;
 
@@ -18,6 +18,8 @@ pub fn render_help_modal(
     scroll_state: &mut ScrollbarState,
     border_type: BorderType,
     theme: &Theme,
+    search: &str,
+    is_searching: bool,
 ) {
     let width_percent = area.width.clamp(30, 120) * 100 / area.width;
     let modal = centered_rect_percent(width_percent, 80, area);
@@ -32,10 +34,19 @@ pub fn render_help_modal(
     );
     frame.render_widget(Clear, modal);
 
-    let instructions = Line::from(vec![
-        " Return ".fg(theme.resolve(&theme.foreground)),
-        "<Esc> ".fg(theme.primary_color).bold(),
-    ]);
+    let instructions = if is_searching || !search.is_empty() {
+        Line::from(vec![
+            Span::raw("Search: "),
+            Span::styled(search, Style::default().fg(theme.primary_color).bold()),
+            Span::raw("  "),
+            "Press <Esc> to exit search mode".fg(theme.primary_color).bold(),
+        ])
+    } else {
+        Line::from(vec![
+            " Return ".fg(theme.resolve(&theme.foreground)),
+            "<Esc>/ ".fg(theme.primary_color).bold(),
+        ])
+    };
 
     let block = Block::default()
         .title("Keymap")
@@ -117,10 +128,37 @@ pub fn render_help_modal(
             .push(key.clone());
     }
 
+    let search_active = !search.is_empty();
+    let search_norm = normalize_for_search(search);
+
     let mut rows = Vec::new();
     rows.push(Row::new(vec![Cell::from(""), Cell::from(""), Cell::from("")]));
 
     for (category, actions) in grouped {
+        // getting all keymaps
+        let filtered_actions: IndexMap<Action, Vec<KeyCombination>> = if search_active {
+            actions
+                .into_iter()
+                .filter(|(action, keys)| {
+                    let key_str = if keys.is_empty() {
+                        String::from("(unbound)")
+                    } else {
+                        keys.iter().map(key_to_ui_string).collect::<Vec<_>>().join(", ")
+                    };
+                    let haystack = format!("{} {} {}", key_str, action.to_config_string(), action.description());
+                    let haystack_norm = normalize_for_search(&haystack);
+                    // finding results
+                    !find_all_subsequences(&search_norm, &haystack_norm).is_empty()
+                })
+                .collect()
+        } else {
+            actions
+        };
+
+        if filtered_actions.is_empty() {
+            continue;
+        }
+
         // category header
         rows.push(
             Row::new(vec![
@@ -131,7 +169,7 @@ pub fn render_help_modal(
             .style(Style::default().fg(theme.primary_color).add_modifier(Modifier::BOLD)),
         );
 
-        for (action, keys) in actions {
+        for (action, keys) in filtered_actions {
             let key_cell = match keys.len() {
                 0 => Cell::from(Line::from(String::from("(unbound)")).alignment(Alignment::Right))
                     .style(Style::default().fg(theme.resolve(&theme.foreground_dim)).bold()),

--- a/src/help.rs
+++ b/src/help.rs
@@ -175,21 +175,37 @@ pub fn render_help_modal(
         );
 
         for (action, keys) in filtered_actions {
-            let key_cell = match keys.len() {
-                0 => Cell::from(Line::from(String::from("(unbound)")).alignment(Alignment::Right))
-                    .style(Style::default().fg(theme.resolve(&theme.foreground_dim)).bold()),
-                _ => Cell::from(
-                    Line::from(keys.iter().map(key_to_ui_string).collect::<Vec<_>>().join(", "))
-                        .alignment(Alignment::Right)
-                        .style(Style::default().fg(theme.resolve(&theme.foreground)).bold()),
-                ),
+            let key_str = if keys.is_empty() {
+                String::from("(unbound)")
+            } else {
+                keys.iter().map(key_to_ui_string).collect::<Vec<_>>().join(", ")
             };
+
+            let key_style = if keys.is_empty() {
+                // unbounded styling
+                Style::default().fg(theme.resolve(&theme.foreground_dim)).bold()
+            } else {
+                Style::default().fg(theme.resolve(&theme.foreground)).bold()
+            };
+
             rows.push(Row::new(vec![
-                key_cell,
-                Cell::from(Line::from(action.to_config_string()).alignment(Alignment::Center))
-                    .style(Style::default().fg(theme.resolve(&theme.foreground))),
-                Cell::from(Line::from(action.description()).alignment(Alignment::Left))
-                    .style(Style::default().fg(theme.resolve(&theme.foreground))),
+                Cell::from(
+                    highlighted_line(&key_str, &search_norm, key_style).alignment(Alignment::Right),
+                ),
+                {
+                    let style = Style::default().fg(theme.resolve(&theme.foreground));
+                    Cell::from(
+                        highlighted_line(&action.to_config_string(), &search_norm, style)
+                            .alignment(Alignment::Center),
+                    )
+                },
+                {
+                    let style = Style::default().fg(theme.resolve(&theme.foreground));
+                    Cell::from(
+                        highlighted_line(&action.description(), &search_norm, style)
+                            .alignment(Alignment::Left),
+                    )
+                },
             ]));
         }
 
@@ -224,6 +240,28 @@ pub fn render_help_modal(
 
     frame.render_widget(table, table_area);
     crate::helpers::render_scrollbar(frame, table_area, scroll_state, theme);
+}
+
+fn highlighted_line(text: &str, search_norm: &str, style: Style) -> Line<'static> {
+    let mut spans = Vec::new();
+    let mut last_end = 0;
+    let all_subsequences = find_all_subsequences(search_norm, &text.to_lowercase());
+
+    for (start, end) in all_subsequences {
+        if last_end < start {
+            spans.push(Span::styled(text[last_end..start].to_string(), style));
+        }
+
+        spans.push(Span::styled(text[start..end].to_string(), style.underlined()));
+
+        last_end = end;
+    }
+
+    if last_end < text.len() {
+        spans.push(Span::styled(text[last_end..].to_string(), style));
+    }
+
+    Line::from(spans)
 }
 
 fn key_to_ui_string(key: &KeyCombination) -> String {

--- a/src/help.rs
+++ b/src/help.rs
@@ -6,6 +6,7 @@ use crate::themes::theme::Theme;
 
 use crokey::{KeyCombination, OneToThree};
 use indexmap::IndexMap;
+use std::collections::HashMap;
 
 use crossterm::event::{KeyCode, KeyModifiers};
 use strum::IntoEnumIterator;
@@ -76,8 +77,6 @@ pub fn render_help_modal(
 
     let mut header_lines = vec![
         Line::from(""),
-        // TODO: remove this debug line
-        Line::from(format!("{:?}", first_match)).alignment(Alignment::Right),
         Line::from("Active key bindings from your configuration")
             .alignment(Alignment::Center)
             .style(Style::default().fg(theme.resolve(&theme.foreground))),
@@ -131,6 +130,21 @@ pub fn render_help_modal(
             .push(key.clone());
     }
 
+    // Build a map from Action to its row index in the full (non-search) table layout.
+    // This is needed so Cancel can scroll to the correct position after exiting search.
+    let mut action_row: HashMap<Action, usize> = HashMap::new();
+    {
+        let mut idx = 1;
+        for (_, actions) in &grouped {
+            idx += 1;
+            for (action, _) in actions {
+                action_row.entry(action.clone()).or_insert(idx);
+                idx += 1;
+            }
+            idx += 1;
+        }
+    }
+
     let search_active = !search.is_empty();
     let search_norm = normalize_for_search(search);
 
@@ -138,56 +152,40 @@ pub fn render_help_modal(
     rows.push(Row::new(vec![Cell::from(""), Cell::from(""), Cell::from("")]));
 
     *first_match = None;
-    let mut row_idx = 1;
-    for (category, actions) in grouped {
-        row_idx += 1;
-        // getting all keymaps
-        let filtered_actions: IndexMap<Action, Vec<KeyCombination>> = if search_active {
-            let a = actions
-                .into_iter()
-                .filter(|(action, keys)| {
-                    let key_str = if keys.is_empty() {
-                        String::from("(unbound)")
-                    } else {
-                        keys.iter().map(key_to_ui_string).collect::<Vec<_>>().join(", ")
-                    };
-                    let haystack = format!(
-                        "{} {} {}",
-                        key_str,
-                        action.to_config_string(),
-                        action.description()
-                    );
-                    let haystack_norm = normalize_for_search(&haystack);
 
-                    // finding results
-                    if !find_all_subsequences(&search_norm, &haystack_norm).is_empty() {
-                        *first_match = Some(row_idx);
-                    }
-                    row_idx += 1;
-                    !find_all_subsequences(&search_norm, &haystack_norm).is_empty()
-                })
-                .collect();
-            row_idx += 1;
-            a
-        } else {
-            actions
-        };
-
-        if filtered_actions.is_empty() {
-            continue;
+    if search_active {
+        let mut all_matches: Vec<(Action, Vec<KeyCombination>)> = Vec::new();
+        for (_, actions) in grouped {
+            for (action, keys) in actions {
+                let key_str = if keys.is_empty() {
+                    String::from("(unbound)")
+                } else {
+                    keys.iter().map(key_to_ui_string).collect::<Vec<_>>().join(", ")
+                };
+                let haystack =
+                    format!("{} {} {}", key_str, action.to_config_string(), action.description());
+                let haystack_norm = normalize_for_search(&haystack);
+                if !find_all_subsequences(&search_norm, &haystack_norm).is_empty() {
+                    // push found string to all_matches
+                    all_matches.push((action, keys));
+                }
+            }
         }
 
-        // category header
-        rows.push(
-            Row::new(vec![
-                Cell::from(""),
-                Cell::from(Line::from(category.title()).alignment(Alignment::Center)),
-                Cell::from(""),
-            ])
-            .style(Style::default().fg(theme.primary_color).add_modifier(Modifier::BOLD)),
-        );
+        all_matches.sort_by_key(|(action, keys)| {
+            let key_str = if keys.is_empty() {
+                String::from("(unbound)")
+            } else {
+                keys.iter().map(key_to_ui_string).collect::<Vec<_>>().join(", ")
+            };
+            // get best match for search: Action -> Key binding -> Description
+            // if user searches for 'reset', try matching Action first
+            relevance_score(&search_norm, &key_str, action)
+        });
 
-        for (action, keys) in filtered_actions {
+        *first_match = all_matches.first().and_then(|(best, _)| action_row.get(best).copied());
+
+        for (action, keys) in &all_matches {
             let key_str = if keys.is_empty() {
                 String::from("(unbound)")
             } else {
@@ -195,7 +193,6 @@ pub fn render_help_modal(
             };
 
             let key_style = if keys.is_empty() {
-                // unbounded styling
                 Style::default().fg(theme.resolve(&theme.foreground_dim)).bold()
             } else {
                 Style::default().fg(theme.resolve(&theme.foreground)).bold()
@@ -221,9 +218,54 @@ pub fn render_help_modal(
                 },
             ]));
         }
+    } else {
+        for (category, actions) in grouped {
+            rows.push(
+                Row::new(vec![
+                    Cell::from(""),
+                    Cell::from(Line::from(category.title()).alignment(Alignment::Center)),
+                    Cell::from(""),
+                ])
+                .style(Style::default().fg(theme.primary_color).add_modifier(Modifier::BOLD)),
+            );
 
-        // spacer row
-        rows.push(Row::new(vec![Cell::from(""), Cell::from(""), Cell::from("")]));
+            for (action, keys) in actions {
+                let key_str = if keys.is_empty() {
+                    String::from("(unbound)")
+                } else {
+                    keys.iter().map(key_to_ui_string).collect::<Vec<_>>().join(", ")
+                };
+
+                let key_style = if keys.is_empty() {
+                    Style::default().fg(theme.resolve(&theme.foreground_dim)).bold()
+                } else {
+                    Style::default().fg(theme.resolve(&theme.foreground)).bold()
+                };
+
+                rows.push(Row::new(vec![
+                    Cell::from(
+                        highlighted_line(&key_str, &search_norm, key_style)
+                            .alignment(Alignment::Right),
+                    ),
+                    {
+                        let style = Style::default().fg(theme.resolve(&theme.foreground));
+                        Cell::from(
+                            highlighted_line(&action.to_config_string(), &search_norm, style)
+                                .alignment(Alignment::Center),
+                        )
+                    },
+                    {
+                        let style = Style::default().fg(theme.resolve(&theme.foreground));
+                        Cell::from(
+                            highlighted_line(&action.description(), &search_norm, style)
+                                .alignment(Alignment::Left),
+                        )
+                    },
+                ]));
+            }
+
+            rows.push(Row::new(vec![Cell::from(""), Cell::from(""), Cell::from("")]));
+        }
     }
 
     let total_rows = rows.len();
@@ -309,6 +351,30 @@ fn key_to_ui_string(key: &KeyCombination) -> String {
     }
 
     s
+}
+
+/// Helper function for handling partial match vs full match
+/// Matches Action -> Keybindings / Description
+fn relevance_score(search_norm: &str, key_str: &str, action: &Action) -> (u8, usize) {
+    let action_norm = normalize_for_search(&action.to_config_string());
+    if let Some(off) = find_all_subsequences(search_norm, &action_norm).first().map(|(s, _)| *s) {
+        // search matches Action, return as best match
+        return (0, off);
+    }
+
+    let desc_norm = normalize_for_search(&action.description());
+    let name_desc_norm = format!("{} {}", action_norm, desc_norm);
+    if let Some(off) = find_all_subsequences(search_norm, &name_desc_norm).first().map(|(s, _)| *s)
+    {
+        return (1, off);
+    }
+
+    let full_norm = format!("{} {}", key_str, name_desc_norm);
+    let off = find_all_subsequences(search_norm, &full_norm)
+        .first()
+        .map(|(s, _)| *s)
+        .unwrap_or(usize::MAX);
+    (2, off)
 }
 
 pub fn build_tab_labels(keymap: &IndexMap<KeyCombination, Action>) -> [String; 4] {

--- a/src/help.rs
+++ b/src/help.rs
@@ -36,15 +36,15 @@ pub fn render_help_modal(
 
     let instructions = if is_searching || !search.is_empty() {
         Line::from(vec![
-            Span::raw("Search: "),
+            Span::raw("Searching: "),
             Span::styled(search, Style::default().fg(theme.primary_color).bold()),
             Span::raw("  "),
-            "Press <Esc> to exit search mode".fg(theme.primary_color).bold(),
+            " Press <Esc> to exit search mode ".fg(theme.primary_color).bold(),
         ])
     } else {
         Line::from(vec![
             " Return ".fg(theme.resolve(&theme.foreground)),
-            "<Esc>/ ".fg(theme.primary_color).bold(),
+            "<Esc> ".fg(theme.primary_color).bold(),
         ])
     };
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -145,7 +145,12 @@ pub fn render_help_modal(
                     } else {
                         keys.iter().map(key_to_ui_string).collect::<Vec<_>>().join(", ")
                     };
-                    let haystack = format!("{} {} {}", key_str, action.to_config_string(), action.description());
+                    let haystack = format!(
+                        "{} {} {}",
+                        key_str,
+                        action.to_config_string(),
+                        action.description()
+                    );
                     let haystack_norm = normalize_for_search(&haystack);
                     // finding results
                     !find_all_subsequences(&search_norm, &haystack_norm).is_empty()

--- a/src/help.rs
+++ b/src/help.rs
@@ -20,6 +20,7 @@ pub fn render_help_modal(
     theme: &Theme,
     search: &str,
     is_searching: bool,
+    first_match: &mut Option<usize>,
 ) {
     let width_percent = area.width.clamp(30, 120) * 100 / area.width;
     let modal = centered_rect_percent(width_percent, 80, area);
@@ -75,6 +76,8 @@ pub fn render_help_modal(
 
     let mut header_lines = vec![
         Line::from(""),
+        // TODO: remove this debug line
+        Line::from(format!("{:?}", first_match)).alignment(Alignment::Right),
         Line::from("Active key bindings from your configuration")
             .alignment(Alignment::Center)
             .style(Style::default().fg(theme.resolve(&theme.foreground))),
@@ -134,10 +137,13 @@ pub fn render_help_modal(
     let mut rows = Vec::new();
     rows.push(Row::new(vec![Cell::from(""), Cell::from(""), Cell::from("")]));
 
+    *first_match = None;
+    let mut row_idx = 1;
     for (category, actions) in grouped {
+        row_idx += 1;
         // getting all keymaps
         let filtered_actions: IndexMap<Action, Vec<KeyCombination>> = if search_active {
-            actions
+            let a = actions
                 .into_iter()
                 .filter(|(action, keys)| {
                     let key_str = if keys.is_empty() {
@@ -152,10 +158,17 @@ pub fn render_help_modal(
                         action.description()
                     );
                     let haystack_norm = normalize_for_search(&haystack);
+
                     // finding results
+                    if !find_all_subsequences(&search_norm, &haystack_norm).is_empty() {
+                        *first_match = Some(row_idx);
+                    }
+                    row_idx += 1;
                     !find_all_subsequences(&search_norm, &haystack_norm).is_empty()
                 })
-                .collect()
+                .collect();
+            row_idx += 1;
+            a
         } else {
             actions
         };

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -466,6 +466,16 @@ impl App {
         }
         // log::debug!("{:?}", crate::helpers::crokey_to_yaml(key_event));
         let combo = KeyCombination::from(key_event);
+
+        // handle searching in help menu
+        if self.help_searching {
+            if let KeyCode::Char(c) = key_event.code {
+                self.dirty = true;
+                self.help_search.push(c);
+                return;
+            }
+        }
+
         // if inputting text, treat any Char events as text input - convert to Type(c)
         if self.locally_searching || self.popup.editing || self.searching {
             if let KeyCode::Char(c) = key_event.code {
@@ -504,6 +514,24 @@ impl App {
         }
 
         if self.show_help {
+            if self.help_searching {
+                match action {
+                    Action::Down => self.state.help_scroll_state.next(),
+                    Action::Up => self.state.help_scroll_state.prev(),
+                    Action::JumpFirst => self.state.help_scroll_state.first(),
+                    Action::JumpLast => self.state.help_scroll_state.last(),
+                    Action::Cancel => {
+                        self.help_search.clear();
+                        self.help_searching = false;
+                    }
+                    Action::Delete => self.help_search.clear(),
+                    Action::DeleteBack => {
+                        self.help_search.pop();
+                    }
+                    _ => {}
+                }
+                return;
+            }
             match action {
                 Action::Down => self.state.help_scroll_state.next(),
                 Action::Up => self.state.help_scroll_state.prev(),
@@ -511,6 +539,7 @@ impl App {
                 Action::JumpFirst => self.state.help_scroll_state.first(),
                 Action::JumpLast => self.state.help_scroll_state.last(),
                 Action::Cancel | Action::Help => self.show_help = false,
+                Action::SearchLocally => self.help_searching = true,
                 _ => {}
             }
             return;

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -472,6 +472,7 @@ impl App {
             if let KeyCode::Char(c) = key_event.code {
                 self.dirty = true;
                 self.help_search.push(c);
+                // self.help_first_match = None;
                 return;
             }
         }
@@ -521,12 +522,20 @@ impl App {
                     Action::JumpFirst => self.state.help_scroll_state.first(),
                     Action::JumpLast => self.state.help_scroll_state.last(),
                     Action::Cancel => {
+                        if let Some(pos) = self.help_first_match {
+                            self.state.help_scroll_state =
+                                self.state.help_scroll_state.position(pos);
+                        }
                         self.help_search.clear();
                         self.help_searching = false;
                     }
-                    Action::Delete => self.help_search.clear(),
+                    Action::Delete => {
+                        self.help_search.clear();
+                        self.help_first_match = None;
+                    }
                     Action::DeleteBack => {
                         self.help_search.pop();
+                        self.help_first_match = None;
                     }
                     _ => {}
                 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -255,6 +255,8 @@ pub struct App {
 
     pub searching: bool,
     pub show_help: bool,
+    pub help_search: String,
+    pub help_searching: bool,
     pub search_term: String,
     pub search_term_last: String,
 
@@ -556,6 +558,8 @@ impl App {
             show_help: false,
             search_term: String::from(""),
             search_term_last: String::from(""),
+            help_search: String::from(""),
+            help_searching: false,
 
             locally_searching: false,
 
@@ -1914,6 +1918,8 @@ impl App {
                 &mut self.state.help_scroll_state,
                 self.border_type,
                 &self.theme,
+                &self.help_search,
+                self.help_searching,
             );
         }
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -257,6 +257,7 @@ pub struct App {
     pub show_help: bool,
     pub help_search: String,
     pub help_searching: bool,
+    pub help_first_match: Option<usize>,
     pub search_term: String,
     pub search_term_last: String,
 
@@ -560,6 +561,7 @@ impl App {
             search_term_last: String::from(""),
             help_search: String::from(""),
             help_searching: false,
+            help_first_match: None,
 
             locally_searching: false,
 
@@ -1920,6 +1922,7 @@ impl App {
                 &self.theme,
                 &self.help_search,
                 self.help_searching,
+                &mut self.help_first_match,
             );
         }
     }


### PR DESCRIPTION
I was having trouble finding configured keymaps. 

This PR fixes this by implementing search functionality for the ? Help menu. Press / to search for existing key maps

Note that I'm a noob Rust dev, I did write the code myself, please verify if everything is ok.
