### PR TITLE
Feature Request: Emit accent color to local data dir and fix no-cover fallback

### DIFF
--- a/src/themes/theme.rs
+++ b/src/themes/theme.rs
@@ -267,6 +267,16 @@ impl Theme {
         self.last_primary = self.primary_color;
         self.target_primary = color;
         self.lerp_elapsed_ms = 0;
+        Self::write_accent_color_file(color);
+    }
+
+    pub(crate) fn write_accent_color_file(color: Color) {
+        if let Color::Rgb(r, g, b) = color {
+            if let Some(config_dir) = dirs::config_dir() {
+                let path = config_dir.join("jellyfin-tui").join("accent_color");
+                let _ = std::fs::write(&path, format!("#{:02x}{:02x}{:02x}", r, g, b));
+            }
+        }
     }
 
     pub fn tick_lerp(&mut self, dt_ms: u64, lerp_duration_ms: u64) -> bool {

--- a/src/themes/theme.rs
+++ b/src/themes/theme.rs
@@ -267,16 +267,6 @@ impl Theme {
         self.last_primary = self.primary_color;
         self.target_primary = color;
         self.lerp_elapsed_ms = 0;
-        Self::write_accent_color_file(color);
-    }
-
-    pub(crate) fn write_accent_color_file(color: Color) {
-        if let Color::Rgb(r, g, b) = color {
-            if let Some(config_dir) = dirs::config_dir() {
-                let path = config_dir.join("jellyfin-tui").join("accent_color");
-                let _ = std::fs::write(&path, format!("#{:02x}{:02x}{:02x}", r, g, b));
-            }
-        }
     }
 
     pub fn tick_lerp(&mut self, dt_ms: u64, lerp_duration_ms: u64) -> bool {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1763,15 +1763,22 @@ impl App {
                             self.grab_primary_color(&p);
                         } else {
                             let fallback = self.theme.resolve(&self.theme.accent);
-                            self.theme.primary_color = fallback;
-                            Theme::write_accent_color_file(fallback);
+                            self.theme.set_primary_color(fallback);
+                            Self::write_accent_color_file(fallback);
                         }
+                    } else {
+                        let fallback = self.theme.resolve(&self.theme.accent);
+                        self.theme.set_primary_color(fallback);
+                        Self::write_accent_color_file(fallback);
                     }
                 }
                 Err(_) => {
                     if second_attempt {
                         self.cover_art = None;
                         self.cover_art_path.clear();
+                        let fallback = self.theme.resolve(&self.theme.accent);
+                        self.theme.set_primary_color(fallback);
+                        Self::write_accent_color_file(fallback);
                     }
                 }
             }
@@ -2345,6 +2352,33 @@ impl App {
         (rgba.to_vec(), color_thief::ColorFormat::Rgba)
     }
 
+    fn write_accent_color_file(color: Color) {
+        let Color::Rgb(r, g, b) = color else {
+            return;
+        };
+
+        let Some(data_dir) = data_dir() else {
+            log::debug!("Could not write accent color file: data dir not available");
+            return;
+        };
+
+        let path = data_dir.join("jellyfin-tui").join("accent_color");
+        if let Some(parent) = path.parent() {
+            if let Err(err) = std::fs::create_dir_all(parent) {
+                log::debug!(
+                    "Could not write accent color file (create dir {}): {}",
+                    parent.display(),
+                    err
+                );
+                return;
+            }
+        }
+
+        if let Err(err) = std::fs::write(&path, format!("#{:02x}{:02x}{:02x}", r, g, b)) {
+            log::debug!("Could not write accent color file ({}): {}", path.display(), err);
+        }
+    }
+
     fn grab_primary_color(&mut self, p: &str) {
         if !self.auto_color {
             return;
@@ -2452,7 +2486,9 @@ impl App {
                 b = b.saturating_add(30);
             }
 
-            self.theme.set_primary_color(Color::Rgb(r, g, b));
+            let color = Color::Rgb(r, g, b);
+            self.theme.set_primary_color(color);
+            Self::write_accent_color_file(color);
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1762,7 +1762,9 @@ impl App {
                             }
                             self.grab_primary_color(&p);
                         } else {
-                            self.theme.primary_color = self.theme.resolve(&self.theme.accent);
+                            let fallback = self.theme.resolve(&self.theme.accent);
+                            self.theme.primary_color = fallback;
+                            Theme::write_accent_color_file(fallback);
                         }
                     }
                 }


### PR DESCRIPTION
Closes #213

## Summary
This PR emits the current accent color to `~/.local/share/jellyfin-tui/accent_color` and fixes fallback behavior when no cover art is available.

## What changed
- Moved accent color file emission into the color extraction flow (instead of theme state mutation).
- Writes output to `~/.local/share/jellyfin-tui/accent_color` (same base as `auth_cache.json`).
- Added debug logging when writing the accent file fails.
- Fixed fallback so missing/unreadable cover art reverts to accent and emits that value.
- Kept implementation simple and synchronous (no config toggle, no background thread).

## Files touched
- src/tui.rs
- src/themes/theme.rs

## Validation
- cargo fmt
- cargo test
- Local release build and manual run verification