### PR TITLE
feat: add art_protocol config option to override terminal image protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ servers:
 
 # Show album cover image
 art: true
+# Force a specific image rendering protocol instead of auto-detecting from the terminal.
+# Useful when your terminal reports supporting a pixel protocol but doesn't render it correctly (e.g. Warp).
+# Options: 'halfblocks' (unicode block chars, works everywhere), 'kitty', 'sixel', 'iterm2'
+# art_protocol: halfblocks
 # Save and restore the state of the player (queue, volume, etc.)
 persist: true
 # Grab the primary color from the cover image (false => uses the current theme's `accent` instead)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -49,7 +49,7 @@ use std::path::PathBuf;
 
 use ratatui::{prelude::*, widgets::*, Frame, Terminal};
 
-use ratatui_image::{picker::Picker, protocol::StatefulProtocol};
+use ratatui_image::{picker::{Picker, ProtocolType}, protocol::StatefulProtocol};
 
 use std::time::Duration;
 
@@ -744,13 +744,27 @@ impl App {
     ) -> (Color, Option<Picker>) {
         let is_art_enabled = config.get("art").and_then(|a| a.as_bool()).unwrap_or(true);
         let picker = if is_art_enabled {
-            match Picker::from_query_stdio() {
-                Ok(picker) => Some(picker),
-                Err(_) => {
-                    let picker = Picker::halfblocks();
-                    Some(picker)
-                }
+            let protocol_override = config
+                .get("art_protocol")
+                .and_then(|v| v.as_str())
+                .and_then(|s| match s.to_lowercase().as_str() {
+                    "halfblocks" => Some(ProtocolType::Halfblocks),
+                    "sixel" => Some(ProtocolType::Sixel),
+                    "kitty" => Some(ProtocolType::Kitty),
+                    "iterm2" => Some(ProtocolType::Iterm2),
+                    _ => None,
+                });
+
+            let mut picker = match Picker::from_query_stdio() {
+                Ok(picker) => picker,
+                Err(_) => Picker::halfblocks(),
+            };
+
+            if let Some(protocol) = protocol_override {
+                picker.set_protocol_type(protocol);
             }
+
+            Some(picker)
         } else {
             None
         };


### PR DESCRIPTION
Adds an `art_protocol` config key to force a specific image rendering protocol instead of relying on auto-detection.

Some terminals (e.g. Warp) respond to the stdio protocol query as if they support a pixel protocol, but don't actually render it — so no cover art shows up. Setting `art_protocol: halfblocks` works around this:

```yaml
art_protocol: halfblocks  # or: sixel, kitty, iterm2
```

When unset, behaviour is unchanged — auto-detection runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
