### PR TITLE
Add minimalistic zen mode

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -139,6 +139,8 @@ pub enum Action {
     HeightenPane,
     /// Make current pane shorter
     ShortenPane,
+    /// Toggle zen mode (fullscreen player view)
+    ZenMode,
 
     /// Exit the app
     Quit,
@@ -220,6 +222,7 @@ impl Action {
             Action::ShrinkPane => Cow::Borrowed("Shrink pane width (normal mode)"),
             Action::HeightenPane => Cow::Borrowed("Increase pane height (vertical mode)"),
             Action::ShortenPane => Cow::Borrowed("Shrink pane height (vertical mode)"),
+            Action::ZenMode => Cow::Borrowed("Toggle zen mode"),
             Action::Help => Cow::Borrowed("Open help"),
             // System
             Action::Quit => Cow::Borrowed("Quit application"),
@@ -281,7 +284,8 @@ impl Action {
             | Action::WidenPane
             | Action::ShrinkPane
             | Action::HeightenPane
-            | Action::ShortenPane => ActionCategory::UI,
+            | Action::ShortenPane
+            | Action::ZenMode => ActionCategory::UI,
 
             Action::Quit | Action::Shell(_) | Action::Reset => ActionCategory::System,
         }
@@ -383,6 +387,8 @@ const DEFAULT_BINDINGS: &[(KeyCombination, Action)] = &[
     // popups
     (key!(shift - p), Action::GlobalPopup),
     (key!('p'), Action::Popup),
+    // zen mode
+    (key!('z'), Action::ZenMode),
 ];
 
 pub fn try_load_keymap(
@@ -560,6 +566,26 @@ impl App {
             return;
         }
 
+        if self.zen_mode {
+            match action {
+                Action::Cancel | Action::ZenMode => self.zen_mode = false,
+                Action::Quit => self.exit().await,
+                Action::PlayPause => match self.paused {
+                    true => self.play().await,
+                    false => self.pause().await,
+                },
+                Action::Next => self.next().await,
+                Action::Previous => self.previous().await,
+                Action::Seek(secs) => self.execute_seek(*secs).await,
+                Action::VolumeUp => self.volume_up().await,
+                Action::VolumeDown => self.volume_down().await,
+                Action::Up => {}
+                Action::Down => {}
+                _ => {}
+            }
+            return;
+        }
+
         if self.state.active_tab == ActiveTab::Search {
             self.process_search_tab_action(&action).await;
             return;
@@ -644,6 +670,7 @@ impl App {
             Action::Popup => self.request_popup(false).await,
             Action::GlobalPopup => self.request_popup(true).await,
             Action::CycleRadio => self.cycle_radio().await,
+            Action::ZenMode => self.zen_mode = true,
             // noops
             Action::DeleteBack => {}
             Action::Type(_) => {}

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -577,8 +577,7 @@ impl App {
                 Action::Next => self.next().await,
                 Action::Previous => self.previous().await,
                 Action::Seek(secs) => self.execute_seek(*secs).await,
-                Action::VolumeUp => self.volume_up().await,
-                Action::VolumeDown => self.volume_down().await,
+
                 Action::Up => {}
                 Action::Down => {}
                 _ => {}

--- a/src/library.rs
+++ b/src/library.rs
@@ -1935,7 +1935,18 @@ impl App {
 
         frame.render_widget(Paragraph::new(lines).style(Style::default().fg(self.theme.resolve(&self.theme.foreground))), song_info_area);
 
-        let progress_area = vertical[3];
+        let progress_area = {
+            let centered = Layout::default()
+                .direction(Direction::Horizontal)
+                .flex(Flex::Center)
+                .constraints(vec![
+                    Constraint::Percentage(10),
+                    Constraint::Percentage(80),
+                    Constraint::Percentage(10),
+                ])
+                .split(vertical[3]);
+            centered[1]
+        };
 
         let total_seconds = current_song
             .map(|s| s.run_time_ticks as f64 / 10_000_000.0)

--- a/src/library.rs
+++ b/src/library.rs
@@ -1844,4 +1844,220 @@ impl App {
             progress_bar_area[1],
         );
     }
+
+    pub fn render_zen(&mut self, frame: &mut Frame) {
+        let area = frame.area();
+        let current_song = self.state.queue.get(self.state.current_playback_state.current_index);
+
+        let has_cover = self.cover_art.is_some();
+
+        let vertical = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![
+                Constraint::Percentage(20),
+                Constraint::Percentage(40),
+                Constraint::Percentage(20),
+                Constraint::Percentage(10),
+                Constraint::Percentage(10),
+            ])
+            .split(area);
+
+        let cover_area = vertical[1];
+
+        if has_cover {
+            let image_block = Block::default()
+                .borders(Borders::ALL)
+                .border_type(self.border_type)
+                .border_style(self.theme.resolve(&self.theme.border));
+
+            let inner = image_block.inner(cover_area);
+            frame.render_widget(&image_block, cover_area);
+
+            if let Some(cover_art) = self.cover_art.as_mut() {
+                let img_size = cover_art.size_for(Resize::Scale(None), inner);
+                let centered = Rect {
+                    x: inner.x + (inner.width.saturating_sub(img_size.width)) / 2,
+                    y: inner.y + (inner.height.saturating_sub(img_size.height)) / 2,
+                    width: img_size.width,
+                    height: img_size.height,
+                };
+                let image = StatefulImage::default().resize(Resize::Scale(None));
+                frame.render_stateful_widget(image, centered, cover_art);
+            }
+        }
+
+        let song_info_area = vertical[2];
+
+        let lines: Vec<Line> = match current_song {
+            Some(song) => {
+                let title = Line::from(vec![
+                    Span::styled(
+                        &song.name,
+                        Style::default()
+                            .fg(self.theme.resolve(&self.theme.foreground))
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                ])
+                .centered();
+
+                let artists = Line::from(vec![Span::styled(
+                    song.artists.join(", "),
+                    Style::default().fg(self.theme.resolve(&self.theme.foreground_secondary)),
+                )])
+                .centered();
+
+                let album = if song.production_year > 0 {
+                    Line::from(vec![
+                        Span::styled(
+                            &song.album,
+                            Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
+                        ),
+                        Span::styled(
+                            format!(" ({})", song.production_year),
+                            Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
+                        ),
+                    ])
+                    .centered()
+                } else {
+                    Line::from(vec![Span::styled(
+                        &song.album,
+                        Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
+                    )])
+                    .centered()
+                };
+
+                vec![title, artists, album]
+            }
+            None => vec![Line::from("No track playing")
+                .fg(self.theme.resolve(&self.theme.foreground))
+                .centered()],
+        };
+
+        frame.render_widget(Paragraph::new(lines).style(Style::default().fg(self.theme.resolve(&self.theme.foreground))), song_info_area);
+
+        let progress_area = vertical[3];
+
+        let total_seconds = current_song
+            .map(|s| s.run_time_ticks as f64 / 10_000_000.0)
+            .unwrap_or(self.state.current_playback_state.duration);
+
+        let visible_position = if self.state.current_playback_state.seek_active {
+            match self.hard_seek_target {
+                Some(position) => position,
+                _ => self.state.current_playback_state.position,
+            }
+        } else {
+            self.state.current_playback_state.position
+        };
+
+        let percentage =
+            if total_seconds > 0.0 { (visible_position / total_seconds) * 100.0 } else { 0.0 };
+
+        let duration = match total_seconds {
+            0.0 => "0:00 / 0:00".to_string(),
+            _ => {
+                let current_time = self.state.current_playback_state.position;
+                format!(
+                    "{}:{:02} / {}:{:02}",
+                    current_time as u32 / 60,
+                    current_time as u32 % 60,
+                    total_seconds as u32 / 60,
+                    total_seconds as u32 % 60
+                )
+            }
+        };
+
+        let progress_layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .flex(Flex::Center)
+            .constraints(vec![Constraint::Fill(100), Constraint::Min(duration.len() as u16 + 5)])
+            .split(progress_area);
+
+        frame.render_widget(
+            LineGauge::default()
+                .filled_style(if self.buffering {
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                        .fg(self.theme.resolve(&self.theme.progress_fill))
+                        .add_modifier(Modifier::BOLD)
+                })
+                .unfilled_style(
+                    Style::default()
+                        .fg(self.theme.resolve(&self.theme.progress_track))
+                        .add_modifier(Modifier::BOLD),
+                )
+                .ratio(percentage.clamp(0.0, 100.0) / 100.0)
+                .label(Line::from(format!(
+                    "{}   {:.0}% ",
+                    if self.buffering {
+                        self.spinner_stages[self.spinner]
+                    } else if self.paused ^ self.swap_play_pause {
+                        "⏸︎"
+                    } else {
+                        "►"
+                    },
+                    percentage,
+                ))),
+            progress_layout[0],
+        );
+
+        frame.render_widget(
+            Paragraph::new(duration)
+                .centered()
+                .style(Style::default().fg(self.theme.resolve(&self.theme.foreground))),
+            progress_layout[1],
+        );
+
+        let hint_area = vertical[4];
+        let hint = Line::from(vec![
+            Span::styled(
+                "Esc",
+                Style::default()
+                    .fg(self.theme.primary_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                " exit zen  •   ",
+                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
+            ),
+            Span::styled(
+                "Space",
+                Style::default()
+                    .fg(self.theme.primary_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                " play/pause  •   ",
+                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
+            ),
+            Span::styled(
+                "N",
+                Style::default()
+                    .fg(self.theme.primary_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                " next  •   Shift+N",
+                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
+            ),
+            Span::styled(
+                " prev  •   ",
+                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
+            ),
+            Span::styled(
+                "← →",
+                Style::default()
+                    .fg(self.theme.primary_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                " seek",
+                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
+            ),
+        ])
+        .centered();
+
+        frame.render_widget(Paragraph::new(hint), hint_area);
+    }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -1851,15 +1851,32 @@ impl App {
 
         let has_cover = self.cover_art.is_some();
 
+        let has_lyrics = self
+            .lyrics
+            .as_ref()
+            .is_some_and(|(_, l, _)| !l.is_empty());
+
         let vertical = Layout::default()
             .direction(Direction::Vertical)
-            .constraints(vec![
-                Constraint::Percentage(5),
-                Constraint::Percentage(65),
-                Constraint::Percentage(15),
-                Constraint::Percentage(10),
-                Constraint::Percentage(5),
-            ])
+            .constraints(
+                if has_lyrics {
+                    vec![
+                        Constraint::Percentage(5),
+                        Constraint::Percentage(55),
+                        Constraint::Percentage(25),
+                        Constraint::Percentage(10),
+                        Constraint::Percentage(5),
+                    ]
+                } else {
+                    vec![
+                        Constraint::Percentage(5),
+                        Constraint::Percentage(65),
+                        Constraint::Percentage(15),
+                        Constraint::Percentage(10),
+                        Constraint::Percentage(5),
+                    ]
+                },
+            )
             .split(area);
 
         let cover_area = vertical[1];
@@ -1926,14 +1943,59 @@ impl App {
                     .centered()
                 };
 
-                vec![title, artists, album]
+                let mut result = vec![title, artists, album];
+
+                if let Some((_, lyrics, time_synced)) = &self.lyrics {
+                    if !lyrics.is_empty() {
+                        result.push(Line::from("").centered());
+
+                        let current_idx = if *time_synced {
+                            self.state.current_lyric
+                        } else {
+                            0
+                        };
+
+                        let start_idx = if current_idx > 0 { current_idx - 1 } else { 0 };
+                        let end_idx = std::cmp::min(start_idx + 3, lyrics.len());
+
+                        for i in start_idx..end_idx {
+                            let lyric = &lyrics[i];
+                            let style = if *time_synced && i == current_idx {
+                                Style::default()
+                                    .fg(self.theme.resolve(&self.theme.foreground))
+                                    .add_modifier(Modifier::BOLD)
+                            } else {
+                                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
+                            };
+                            result.push(
+                                Line::from(vec![Span::styled(
+                                    &lyric.text,
+                                    style,
+                                )])
+                                .centered(),
+                            );
+                        }
+                    }
+                }
+
+                result
             }
             None => vec![Line::from("No track playing")
                 .fg(self.theme.resolve(&self.theme.foreground))
                 .centered()],
         };
 
-        frame.render_widget(Paragraph::new(lines).style(Style::default().fg(self.theme.resolve(&self.theme.foreground))), song_info_area);
+        let content_height = lines.len() as u16;
+        let centered_info = Rect {
+            x: song_info_area.x,
+            y: song_info_area.y + (song_info_area.height.saturating_sub(content_height)) / 2,
+            width: song_info_area.width,
+            height: content_height,
+        };
+        frame.render_widget(
+            Paragraph::new(lines).style(Style::default().fg(self.theme.resolve(&self.theme.foreground))),
+            centered_info,
+        );
 
         let progress_area = {
             let centered = Layout::default()

--- a/src/library.rs
+++ b/src/library.rs
@@ -1854,8 +1854,8 @@ impl App {
         let vertical = Layout::default()
             .direction(Direction::Vertical)
             .constraints(vec![
-                Constraint::Percentage(10),
-                Constraint::Percentage(60),
+                Constraint::Percentage(5),
+                Constraint::Percentage(65),
                 Constraint::Percentage(15),
                 Constraint::Percentage(10),
                 Constraint::Percentage(5),
@@ -1865,19 +1865,19 @@ impl App {
         let cover_area = vertical[1];
 
         if has_cover {
-            let image_block = Block::default()
-                .borders(Borders::ALL)
-                .border_type(self.border_type)
-                .border_style(self.theme.resolve(&self.theme.border));
-
-            let inner = image_block.inner(cover_area);
-            frame.render_widget(&image_block, cover_area);
+            let margin = 1;
+            let inset = Rect {
+                x: cover_area.x + margin,
+                y: cover_area.y + margin,
+                width: cover_area.width.saturating_sub(margin * 2),
+                height: cover_area.height.saturating_sub(margin * 2),
+            };
 
             if let Some(cover_art) = self.cover_art.as_mut() {
-                let img_size = cover_art.size_for(Resize::Scale(None), inner);
+                let img_size = cover_art.size_for(Resize::Scale(None), inset);
                 let centered = Rect {
-                    x: inner.x + (inner.width.saturating_sub(img_size.width)) / 2,
-                    y: inner.y + (inner.height.saturating_sub(img_size.height)) / 2,
+                    x: inset.x + (inset.width.saturating_sub(img_size.width)) / 2,
+                    y: inset.y + (inset.height.saturating_sub(img_size.height)) / 2,
                     width: img_size.width,
                     height: img_size.height,
                 };

--- a/src/library.rs
+++ b/src/library.rs
@@ -1854,11 +1854,11 @@ impl App {
         let vertical = Layout::default()
             .direction(Direction::Vertical)
             .constraints(vec![
-                Constraint::Percentage(20),
-                Constraint::Percentage(40),
-                Constraint::Percentage(20),
                 Constraint::Percentage(10),
+                Constraint::Percentage(60),
+                Constraint::Percentage(15),
                 Constraint::Percentage(10),
+                Constraint::Percentage(5),
             ])
             .split(area);
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -1851,32 +1851,27 @@ impl App {
 
         let has_cover = self.cover_art.is_some();
 
-        let has_lyrics = self
-            .lyrics
-            .as_ref()
-            .is_some_and(|(_, l, _)| !l.is_empty());
+        let has_lyrics = self.lyrics.as_ref().is_some_and(|(_, l, _)| !l.is_empty());
 
         let vertical = Layout::default()
             .direction(Direction::Vertical)
-            .constraints(
-                if has_lyrics {
-                    vec![
-                        Constraint::Percentage(5),
-                        Constraint::Percentage(55),
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(10),
-                        Constraint::Percentage(5),
-                    ]
-                } else {
-                    vec![
-                        Constraint::Percentage(5),
-                        Constraint::Percentage(65),
-                        Constraint::Percentage(15),
-                        Constraint::Percentage(10),
-                        Constraint::Percentage(5),
-                    ]
-                },
-            )
+            .constraints(if has_lyrics {
+                vec![
+                    Constraint::Percentage(5),
+                    Constraint::Percentage(55),
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(10),
+                    Constraint::Percentage(5),
+                ]
+            } else {
+                vec![
+                    Constraint::Percentage(5),
+                    Constraint::Percentage(65),
+                    Constraint::Percentage(15),
+                    Constraint::Percentage(10),
+                    Constraint::Percentage(5),
+                ]
+            })
             .split(area);
 
         let cover_area = vertical[1];
@@ -1891,7 +1886,8 @@ impl App {
             };
 
             if let Some(cover_art) = self.cover_art.as_mut() {
-                let img_size = cover_art.size_for(Resize::Scale(None), inset);
+                let img_size =
+                    cover_art.size_for(Resize::Scale(None), Size::new(inset.width, inset.height));
                 let centered = Rect {
                     x: inset.x + (inset.width.saturating_sub(img_size.width)) / 2,
                     y: inset.y + (inset.height.saturating_sub(img_size.height)) / 2,
@@ -1907,14 +1903,12 @@ impl App {
 
         let lines: Vec<Line> = match current_song {
             Some(song) => {
-                let title = Line::from(vec![
-                    Span::styled(
-                        &song.name,
-                        Style::default()
-                            .fg(self.theme.resolve(&self.theme.foreground))
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                ])
+                let title = Line::from(vec![Span::styled(
+                    &song.name,
+                    Style::default()
+                        .fg(self.theme.resolve(&self.theme.foreground))
+                        .add_modifier(Modifier::BOLD),
+                )])
                 .centered();
 
                 let artists = Line::from(vec![Span::styled(
@@ -1949,11 +1943,7 @@ impl App {
                     if !lyrics.is_empty() {
                         result.push(Line::from("").centered());
 
-                        let current_idx = if *time_synced {
-                            self.state.current_lyric
-                        } else {
-                            0
-                        };
+                        let current_idx = if *time_synced { self.state.current_lyric } else { 0 };
 
                         let start_idx = if current_idx > 0 { current_idx - 1 } else { 0 };
                         let end_idx = std::cmp::min(start_idx + 3, lyrics.len());
@@ -1968,11 +1958,7 @@ impl App {
                                 Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
                             };
                             result.push(
-                                Line::from(vec![Span::styled(
-                                    &lyric.text,
-                                    style,
-                                )])
-                                .centered(),
+                                Line::from(vec![Span::styled(&lyric.text, style)]).centered(),
                             );
                         }
                     }
@@ -1993,7 +1979,8 @@ impl App {
             height: content_height,
         };
         frame.render_widget(
-            Paragraph::new(lines).style(Style::default().fg(self.theme.resolve(&self.theme.foreground))),
+            Paragraph::new(lines)
+                .style(Style::default().fg(self.theme.resolve(&self.theme.foreground))),
             centered_info,
         );
 
@@ -2064,11 +2051,11 @@ impl App {
                 .label(Line::from(format!(
                     "{}   {:.0}% ",
                     if self.buffering {
-                        self.spinner_stages[self.spinner]
+                        self.spinner_stages[self.spinner].clone()
                     } else if self.paused ^ self.swap_play_pause {
-                        "⏸︎"
+                        "⏸︎".to_string()
                     } else {
-                        "►"
+                        "►".to_string()
                     },
                     percentage,
                 ))),

--- a/src/library.rs
+++ b/src/library.rs
@@ -2022,50 +2022,16 @@ impl App {
 
         let hint_area = vertical[4];
         let hint = Line::from(vec![
-            Span::styled(
-                "Esc",
-                Style::default()
-                    .fg(self.theme.primary_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " exit zen  •   ",
-                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
-            ),
-            Span::styled(
-                "Space",
-                Style::default()
-                    .fg(self.theme.primary_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " play/pause  •   ",
-                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
-            ),
-            Span::styled(
-                "N",
-                Style::default()
-                    .fg(self.theme.primary_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " next  •   Shift+N",
-                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
-            ),
-            Span::styled(
-                " prev  •   ",
-                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
-            ),
-            Span::styled(
-                "← →",
-                Style::default()
-                    .fg(self.theme.primary_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " seek",
-                Style::default().fg(self.theme.resolve(&self.theme.foreground_dim)),
-            ),
+            " Exit ".fg(self.theme.resolve(&self.theme.foreground)),
+            "<Esc>".fg(self.theme.primary_color).bold(),
+            " Play/Pause ".fg(self.theme.resolve(&self.theme.foreground)),
+            "<Space>".fg(self.theme.primary_color).bold(),
+            " Next ".fg(self.theme.resolve(&self.theme.foreground)),
+            "<N>".fg(self.theme.primary_color).bold(),
+            " Prev ".fg(self.theme.resolve(&self.theme.foreground)),
+            "<Shift+N>".fg(self.theme.primary_color).bold(),
+            " Seek ".fg(self.theme.resolve(&self.theme.foreground)),
+            "<← →>".fg(self.theme.primary_color).bold(),
         ])
         .centered();
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1928,6 +1928,8 @@ impl App {
                     &mut self.state.help_scroll_state,
                     self.border_type,
                     &self.theme,
+                    &self.help_search,
+                    self.help_searching,
                 );
             }
             return;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -259,6 +259,7 @@ pub struct App {
     pub show_help: bool,
     pub help_search: String,
     pub help_searching: bool,
+    pub zen_mode: bool,
     pub search_term: String,
     pub search_term_last: String,
 
@@ -567,6 +568,7 @@ impl App {
 
             searching: false,
             show_help: false,
+            zen_mode: false,
             search_term: String::from(""),
             search_term_last: String::from(""),
             help_search: String::from(""),
@@ -1913,6 +1915,22 @@ impl App {
         if let Some(background) = self.theme.resolve_opt(&self.theme.background) {
             let background_block = Block::default().style(Style::default().bg(background));
             frame.render_widget(background_block, frame.area());
+        }
+
+        if self.zen_mode {
+            self.render_zen(frame);
+            if self.show_help {
+                render_help_modal(
+                    frame,
+                    frame.area(),
+                    &self.keymap,
+                    &self.keymap_error,
+                    &mut self.state.help_scroll_state,
+                    self.border_type,
+                    &self.theme,
+                );
+            }
+            return;
         }
 
         let app_container = Layout::default()


### PR DESCRIPTION
Adds a zen mode that hides all panes except the player when pressing `Z`.

Features:
- Toggle fullscreen player view with `Z` keybinding
- Displays lyrics when available
- Minimal UI with adjusted margins and progress bar
- Borders removed around cover art for a cleaner look

Discussion details: https://github.com/dhonus/jellyfin-tui/discussions/188