### PR TITLE
fix: wrap blocking config init in spawn_blocking to prevent runtime drop panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,11 @@ async fn main() {
 
     log::info!("jellyfin-tui {} started", version);
 
-    config::initialize_config();
+    tokio::task::spawn_blocking(|| {
+        config::initialize_config();
+    })
+    .await
+    .expect("spawn_blocking for initialize_config panicked");
 
     let mut app = tui::App::new(offline, force_server_select).await;
     if let Err(e) = app.load_state().await {


### PR DESCRIPTION
Fixes #223

## Description

Running `jellyfin-tui` without an existing config file causes a panic:
```
Cannot drop a runtime in a context where blocking is not allowed.
```

## Root Cause

`config::initialize_config()` creates a `reqwest::blocking::Client` which internally creates its own Tokio runtime. When the client drops at function exit, the inner runtime is dropped inside the active `#[tokio::main]` runtime — which is forbidden.

## Fix

Wrap the call in `tokio::task::spawn_blocking()` so the blocking client's inner runtime is dropped on a blocking thread pool thread instead of the main async worker thread.

Most users don't hit this because `initialize_config()` has an early return when a config file already exists. Only fresh installs or config format upgrades trigger the blocking code path.