### PR TITLE
Select mode to remove multiple tracks from playlists

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -594,7 +594,7 @@ impl App {
                 match action {
                     Action::Cancel | Action::ToggleSelectMode => self.exit_playlist_select_mode(),
                     Action::PlayPause | Action::Enter => self.toggle_playlist_selection(),
-                    Action::Download => self.request_playlist_selection_removal(),
+                    Action::Delete => self.request_playlist_selection_removal(),
                     // navigation keeps working while selecting
                     Action::Up => self.select_previous(),
                     Action::Down => self.select_next(),
@@ -3177,7 +3177,8 @@ impl App {
         }
 
         // select mode only makes sense in the playlist tracks pane
-        if self.playlist_editing
+        if self.client.is_none()
+            || self.playlist_editing
             || self.playlist_incomplete
             || self.playlist_stale
             || self.state.active_tab != ActiveTab::Playlists
@@ -3188,7 +3189,7 @@ impl App {
 
         self.playlist_select_mode = true;
 
-        // seed the selection with the track under the cursor so `d` alone removes it
+        // seed the selection with the track under the cursor so Delete alone removes it
         if self.playlist_selected_items.is_empty() {
             let key = self.selected_playlist_track().map(Self::playlist_track_key);
             if let Some(key) = key {
@@ -3250,7 +3251,7 @@ impl App {
         if !self.playlist_select_mode || self.playlist_selected_items.is_empty() {
             return;
         }
-        if self.client.is_none() || self.state.current_playlist.id.is_empty() {
+        if self.state.current_playlist.id.is_empty() {
             return;
         }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -3258,7 +3258,7 @@ impl App {
         self.popup.global = false;
         self.state.last_section = self.state.active_section;
         self.state.active_section = ActiveSection::Popup;
-        self.popup.current_menu = Some(crate::popup::PopupMenu::PlaylistTracksRemoveMany {
+        self.popup.current_menu = Some(crate::popup::PopupMenu::PlaylistTracksRemove {
             count: self.playlist_selected_items.len(),
             keys: self.playlist_selected_items.iter().cloned().collect(),
             playlist_name: self.state.current_playlist.name.clone(),

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -153,6 +153,8 @@ pub enum Action {
     CollapseAlbum,
     /// Fold every album in the discography pane, or unfold them all
     CollapseAllAlbums,
+    /// Toggle select mode in the playlist tracks pane, to remove multiple tracks at once
+    ToggleSelectMode,
 }
 
 impl Action {
@@ -235,6 +237,9 @@ impl Action {
             Action::Reset => Cow::Borrowed("Reset state"),
             Action::CollapseAlbum => Cow::Borrowed("Fold / unfold selected album"),
             Action::CollapseAllAlbums => Cow::Borrowed("Fold / unfold all albums"),
+            Action::ToggleSelectMode => Cow::Borrowed(
+                "Toggle select mode (space toggles a track, d removes selected, esc exits)",
+            ),
         }
     }
 
@@ -294,7 +299,8 @@ impl Action {
             | Action::ShortenPane
             | Action::ZenMode
             | Action::CollapseAlbum
-            | Action::CollapseAllAlbums => ActionCategory::UI,
+            | Action::CollapseAllAlbums
+            | Action::ToggleSelectMode => ActionCategory::UI,
 
             Action::Quit | Action::Shell(_) | Action::Reset => ActionCategory::System,
         }
@@ -401,6 +407,8 @@ const DEFAULT_BINDINGS: &[(KeyCombination, Action)] = &[
     // album folding
     (key!('o'), Action::CollapseAlbum),
     (key!(shift - o), Action::CollapseAllAlbums),
+    // playlist select mode
+    (key!('v'), Action::ToggleSelectMode),
 ];
 
 pub fn try_load_keymap(
@@ -578,6 +586,37 @@ impl App {
             return;
         }
 
+        if self.playlist_select_mode {
+            // leaving the playlist tracks pane automatically exits select mode
+            if self.state.active_tab != ActiveTab::Playlists
+                || self.state.active_section != ActiveSection::Tracks
+            {
+                self.exit_playlist_select_mode();
+            } else {
+                match action {
+                    Action::Cancel | Action::ToggleSelectMode => self.exit_playlist_select_mode(),
+                    Action::PlayPause | Action::Enter => self.toggle_playlist_selection(),
+                    Action::Download => self.remove_selected_playlist_tracks().await,
+                    // navigation keeps working while selecting
+                    Action::Up => self.select_previous(),
+                    Action::Down => self.select_next(),
+                    Action::Jump(lines) => self.jump(*lines),
+                    Action::PageUp => self.page_up(),
+                    Action::PageDown => self.page_down(),
+                    Action::JumpFirst => self.go_first(),
+                    Action::JumpLast => self.go_last(),
+                    Action::JumpForward => self.jump_forward(),
+                    Action::JumpBackward => self.jump_backward(),
+                    Action::Quit => self.exit().await,
+                    Action::Help => self.show_help(),
+                    Action::Popup => self.request_popup(false).await,
+                    Action::GlobalPopup => self.request_popup(true).await,
+                    _ => return,
+                }
+            }
+            return;
+        }
+
         if self.zen_mode {
             match action {
                 Action::Cancel | Action::ZenMode => self.zen_mode = false,
@@ -653,6 +692,7 @@ impl App {
             Action::Reset => self.reset().await,
             Action::CollapseAlbum => self.toggle_collapse_album(),
             Action::CollapseAllAlbums => self.toggle_all_albums_collapse(),
+            Action::ToggleSelectMode => self.toggle_playlist_select_mode(),
             Action::ToggleTranscode => self.toggle_transcoding().await,
             Action::Volume(delta) => self.volume_delta(*delta).await,
             Action::Up => self.select_previous(),
@@ -3075,7 +3115,10 @@ impl App {
     }
 
     fn begin_playlist_edit(&mut self) {
-        if self.playlist_editing || !self.state.playlist_tracks_search_term.is_empty() {
+        if self.playlist_editing
+            || self.playlist_select_mode
+            || !self.state.playlist_tracks_search_term.is_empty()
+        {
             return;
         }
 
@@ -3126,6 +3169,128 @@ impl App {
         self.playlist_editing = false;
         self.playlist_edit_item_id = None;
         self.playlist_edit_origin_index = None;
+    }
+
+    /// Enter or exit playlist select mode, used to remove multiple tracks from a playlist at once.
+    pub fn toggle_playlist_select_mode(&mut self) {
+        if self.playlist_select_mode {
+            self.exit_playlist_select_mode();
+            return;
+        }
+
+        // select mode only makes sense in the playlist tracks pane
+        if self.playlist_editing
+            || self.playlist_incomplete
+            || self.playlist_stale
+            || self.state.active_tab != ActiveTab::Playlists
+            || self.state.active_section != ActiveSection::Tracks
+        {
+            return;
+        }
+
+        self.playlist_select_mode = true;
+
+        // seed the selection with the track under the cursor so `d` alone removes it
+        if self.playlist_selected_items.is_empty() {
+            let key = self.selected_playlist_track().map(Self::playlist_track_key);
+            if let Some(key) = key {
+                if !key.is_empty() {
+                    self.playlist_selected_items.insert(key);
+                }
+            }
+        }
+        self.dirty = true;
+    }
+
+    pub fn exit_playlist_select_mode(&mut self) {
+        if !self.playlist_select_mode {
+            return;
+        }
+        self.playlist_select_mode = false;
+        self.playlist_selected_items.clear();
+        self.dirty = true;
+    }
+
+    /// The track currently under the cursor in the playlist tracks pane, respecting the search
+    /// filter. `None` if there is nothing to select.
+    fn selected_playlist_track(&self) -> Option<&DiscographySong> {
+        let idx = self.state.selected_playlist_track.selected().unwrap_or(0);
+        search_ranked_refs(&self.playlist_tracks, &self.state.playlist_tracks_search_term, true)
+            .get(idx)
+            .copied()
+    }
+
+    /// Stable key for marking a playlist track in select mode. Prefers the playlist entry id, but
+    /// falls back to the media id, matching how single tracks are removed today.
+    pub(crate) fn playlist_track_key(track: &DiscographySong) -> String {
+        if track.playlist_item_id.is_empty() {
+            track.id.clone()
+        } else {
+            track.playlist_item_id.clone()
+        }
+    }
+
+    /// Toggle the track under the cursor in/out of the selection (space / enter in select mode).
+    pub fn toggle_playlist_selection(&mut self) {
+        if !self.playlist_select_mode {
+            return;
+        }
+        let Some(key) = self.selected_playlist_track().map(Self::playlist_track_key) else {
+            return;
+        };
+        if key.is_empty() {
+            return;
+        }
+        if !self.playlist_selected_items.remove(&key) {
+            self.playlist_selected_items.insert(key);
+        }
+        self.dirty = true;
+    }
+
+    /// Remove every selected track from the current playlist, then leave select mode.
+    pub async fn remove_selected_playlist_tracks(&mut self) {
+        if !self.playlist_select_mode || self.playlist_selected_items.is_empty() {
+            return;
+        }
+
+        let Some(client) = self.client.as_ref() else { return };
+        let playlist_id = self.state.current_playlist.id.clone();
+        if playlist_id.is_empty() {
+            return;
+        }
+        let playlist_name = self.state.current_playlist.name.clone();
+
+        let selected: Vec<String> = self.playlist_selected_items.iter().cloned().collect();
+        let mut removed_ok = 0usize;
+        for key in &selected {
+            if client.remove_from_playlist(key, &playlist_id).await.is_ok() {
+                removed_ok += 1;
+            }
+        }
+
+        if removed_ok > 0 {
+            let selection = &self.playlist_selected_items;
+            self.playlist_tracks.retain(|t| {
+                let key = if t.playlist_item_id.is_empty() {
+                    t.id.clone()
+                } else {
+                    t.playlist_item_id.clone()
+                };
+                !selection.contains(&key)
+            });
+            self.playlist_track_select_by_index(0);
+            self.set_generic_message(
+                "Tracks removed",
+                &format!("Removed {} track(s) from {}.", removed_ok, playlist_name),
+            );
+        } else {
+            self.set_generic_message(
+                "Error removing tracks",
+                &format!("Failed to remove selected tracks from {}.", playlist_name),
+            );
+        }
+
+        self.exit_playlist_select_mode();
     }
 
     async fn global_search(&mut self) {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -237,9 +237,7 @@ impl Action {
             Action::Reset => Cow::Borrowed("Reset state"),
             Action::CollapseAlbum => Cow::Borrowed("Fold / unfold selected album"),
             Action::CollapseAllAlbums => Cow::Borrowed("Fold / unfold all albums"),
-            Action::ToggleSelectMode => Cow::Borrowed(
-                "Toggle select mode (space toggles a track, d removes selected, esc exits)",
-            ),
+            Action::ToggleSelectMode => Cow::Borrowed("Toggle playlist select mode"),
         }
     }
 
@@ -596,7 +594,7 @@ impl App {
                 match action {
                     Action::Cancel | Action::ToggleSelectMode => self.exit_playlist_select_mode(),
                     Action::PlayPause | Action::Enter => self.toggle_playlist_selection(),
-                    Action::Download => self.remove_selected_playlist_tracks().await,
+                    Action::Download => self.request_playlist_selection_removal(),
                     // navigation keeps working while selecting
                     Action::Up => self.select_previous(),
                     Action::Down => self.select_next(),
@@ -3247,9 +3245,31 @@ impl App {
         self.dirty = true;
     }
 
-    /// Remove every selected track from the current playlist, then leave select mode.
-    pub async fn remove_selected_playlist_tracks(&mut self) {
+    /// Ask for confirmation before removing every selected track from the current playlist.
+    pub fn request_playlist_selection_removal(&mut self) {
         if !self.playlist_select_mode || self.playlist_selected_items.is_empty() {
+            return;
+        }
+        if self.client.is_none() || self.state.current_playlist.id.is_empty() {
+            return;
+        }
+
+        self.popup.global = false;
+        self.state.last_section = self.state.active_section;
+        self.state.active_section = ActiveSection::Popup;
+        self.popup.current_menu = Some(crate::popup::PopupMenu::PlaylistTracksRemoveMany {
+            count: self.playlist_selected_items.len(),
+            keys: self.playlist_selected_items.iter().cloned().collect(),
+            playlist_name: self.state.current_playlist.name.clone(),
+            playlist_id: self.state.current_playlist.id.clone(),
+        });
+        self.popup.selected.select(Some(1));
+    }
+
+    /// Remove the given tracks (playlist entry ids, or media ids as fallback) from the current
+    /// playlist, then leave select mode.
+    pub async fn remove_playlist_tracks(&mut self, keys: Vec<String>) {
+        if keys.is_empty() {
             return;
         }
 
@@ -3260,16 +3280,15 @@ impl App {
         }
         let playlist_name = self.state.current_playlist.name.clone();
 
-        let selected: Vec<String> = self.playlist_selected_items.iter().cloned().collect();
         let mut removed_ok = 0usize;
-        for key in &selected {
+        for key in &keys {
             if client.remove_from_playlist(key, &playlist_id).await.is_ok() {
                 removed_ok += 1;
             }
         }
 
         if removed_ok > 0 {
-            let selection = &self.playlist_selected_items;
+            let selection: std::collections::HashSet<&String> = keys.iter().collect();
             self.playlist_tracks.retain(|t| {
                 let key = if t.playlist_item_id.is_empty() {
                     t.id.clone()

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -225,6 +225,8 @@ impl App {
                 {
                     return Row::default();
                 }
+                let is_selected = self.playlist_select_mode
+                    && self.playlist_selected_items.contains(&Self::playlist_track_key(track));
                 // track.run_time_ticks is in microseconds
                 let seconds = (track.run_time_ticks / 10_000_000) % 60;
                 let minutes = (track.run_time_ticks / 10_000_000 / 60) % 60;
@@ -270,7 +272,12 @@ impl App {
 
                 let mut cells = vec![
                     // No.
-                    Cell::from(format!("{}.", i + 1)).style(if track.id == self.active_song_id {
+                    Cell::from(if is_selected {
+                        format!("✓{}.", i + 1)
+                    } else {
+                        format!("{}.", i + 1)
+                    })
+                    .style(if track.id == self.active_song_id {
                         Style::default().fg(color)
                     } else {
                         Style::default().fg(Color::DarkGray)
@@ -319,7 +326,11 @@ impl App {
                         .alignment(Alignment::Right),
                 ));
 
-                Row::new(cells).style(if track.id == self.active_song_id {
+                Row::new(cells).style(if is_selected {
+                    Style::default()
+                        .fg(self.theme.primary_color)
+                        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+                } else if track.id == self.active_song_id {
                     Style::default().fg(self.theme.primary_color).italic()
                 } else if track.disliked {
                     Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
@@ -329,7 +340,38 @@ impl App {
             })
             .collect::<Vec<Row>>();
 
-        let track_instructions = if self.playlist_editing {
+        let track_instructions = if self.playlist_select_mode {
+            Line::from(vec![
+                Span::styled(
+                    format!(" {} selected ", self.playlist_selected_items.len()),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    " Toggle ".to_string(),
+                    Style::default().fg(self.theme.resolve(&self.theme.section_title)),
+                ),
+                Span::styled(
+                    "<space>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    " Remove ".to_string(),
+                    Style::default().fg(self.theme.resolve(&self.theme.section_title)),
+                ),
+                Span::styled(
+                    "<d>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    " Exit ".to_string(),
+                    Style::default().fg(self.theme.resolve(&self.theme.section_title)),
+                ),
+                Span::styled(
+                    "<esc>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+            ])
+        } else if self.playlist_editing {
             Line::from(vec![
                 " Moving track".fg(self.theme.primary_color).bold(),
                 " Save ".fg(self.theme.resolve(&self.theme.section_title)),
@@ -346,7 +388,11 @@ impl App {
             ])
         };
         let mut widths = vec![
-            Constraint::Length(items.len().to_string().len() as u16 + 2),
+            Constraint::Length(
+                items.len().to_string().len() as u16
+                    + 2
+                    + if self.playlist_select_mode { 1 } else { 0 },
+            ),
             Constraint::Percentage(50), // title and track even width
             Constraint::Percentage(25),
             Constraint::Percentage(25),

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -383,6 +383,8 @@ impl App {
             Line::from(vec![
                 " Help ".fg(self.theme.resolve(&self.theme.section_title)),
                 "<?>".fg(self.theme.primary_color).bold(),
+                " Select ".fg(self.theme.resolve(&self.theme.section_title)),
+                "<v>".fg(self.theme.primary_color).bold(),
                 " Quit ".fg(self.theme.resolve(&self.theme.section_title)),
                 "<^C> ".fg(self.theme.primary_color).bold(),
             ])

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -359,7 +359,7 @@ impl App {
                     Style::default().fg(self.theme.resolve(&self.theme.section_title)),
                 ),
                 Span::styled(
-                    "<d>".to_string(),
+                    "<Delete>".to_string(),
                     Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
@@ -380,14 +380,18 @@ impl App {
                 "<ESC> ".fg(self.theme.primary_color).bold(),
             ])
         } else {
-            Line::from(vec![
+            let mut line = vec![
                 " Help ".fg(self.theme.resolve(&self.theme.section_title)),
                 "<?>".fg(self.theme.primary_color).bold(),
-                " Select ".fg(self.theme.resolve(&self.theme.section_title)),
-                "<v>".fg(self.theme.primary_color).bold(),
-                " Quit ".fg(self.theme.resolve(&self.theme.section_title)),
-                "<^C> ".fg(self.theme.primary_color).bold(),
-            ])
+            ];
+            // removing tracks from playlists is not possible while offline
+            if self.client.is_some() {
+                line.push(" Select ".fg(self.theme.resolve(&self.theme.section_title)));
+                line.push("<v>".fg(self.theme.primary_color).bold());
+            }
+            line.push(" Quit ".fg(self.theme.resolve(&self.theme.section_title)));
+            line.push("<^C> ".fg(self.theme.primary_color).bold());
+            Line::from(line)
         };
         let mut widths = vec![
             Constraint::Length(

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -184,6 +184,12 @@ pub enum PopupMenu {
         playlist_name: String,
         playlist_id: String,
     },
+    PlaylistTracksRemoveMany {
+        count: usize,
+        keys: Vec<String>,
+        playlist_name: String,
+        playlist_id: String,
+    },
     /**
      * Artist related popups
      */
@@ -338,6 +344,9 @@ impl PopupMenu {
             PopupMenu::PlaylistTracksRoot { track, .. } => track.name.to_string(),
             PopupMenu::PlaylistTrackAddToPlaylist { track_name, .. } => track_name.to_string(),
             PopupMenu::PlaylistTracksRemove { track_name, .. } => track_name.to_string(),
+            PopupMenu::PlaylistTracksRemoveMany { count, .. } => {
+                format!("Remove {} selected track(s)?", count)
+            }
             // ---------- Artists ---------- //
             PopupMenu::ArtistRoot { artist, .. } => artist.name.to_string(),
             PopupMenu::ArtistJumpToCurrent { artists, .. } => {
@@ -1048,6 +1057,21 @@ impl PopupMenu {
             PopupMenu::PlaylistTracksRemove { track_name, .. } => vec![
                 PopupAction::new(
                     format!("Remove {} from playlist?", track_name),
+                    PopupCommand::None,
+                    Style::default().fg(style::Color::Red),
+                    true,
+                ),
+                PopupAction::new(
+                    "Yes".to_string(),
+                    PopupCommand::Yes,
+                    Style::default().fg(style::Color::Red),
+                    true,
+                ),
+                PopupAction::new("No".to_string(), PopupCommand::No, Style::default(), true),
+            ],
+            PopupMenu::PlaylistTracksRemoveMany { count, .. } => vec![
+                PopupAction::new(
+                    format!("Remove {} selected track(s) from playlist?", count),
                     PopupCommand::None,
                     Style::default().fg(style::Color::Red),
                     true,
@@ -2713,6 +2737,16 @@ impl crate::tui::App {
                         );
                     }
                 }
+                _ => {
+                    self.close_popup();
+                }
+            },
+            PopupMenu::PlaylistTracksRemoveMany { keys, .. } => match action {
+                PopupCommand::Yes => {
+                    self.close_popup();
+                    self.remove_playlist_tracks(keys).await;
+                }
+                // keep the selection intact and stay in select mode
                 _ => {
                     self.close_popup();
                 }

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -178,13 +178,9 @@ pub enum PopupMenu {
         track_id: String,
         playlists: Vec<Playlist>,
     },
+    // Confirmation for removing one or many tracks from a playlist; also used when
+    // removing a selection marked with select mode (`v`)
     PlaylistTracksRemove {
-        track_name: String,
-        track_id: String,
-        playlist_name: String,
-        playlist_id: String,
-    },
-    PlaylistTracksRemoveMany {
         count: usize,
         keys: Vec<String>,
         playlist_name: String,
@@ -343,8 +339,7 @@ impl PopupMenu {
             // ---------- Playlist tracks ---------- //
             PopupMenu::PlaylistTracksRoot { track, .. } => track.name.to_string(),
             PopupMenu::PlaylistTrackAddToPlaylist { track_name, .. } => track_name.to_string(),
-            PopupMenu::PlaylistTracksRemove { track_name, .. } => track_name.to_string(),
-            PopupMenu::PlaylistTracksRemoveMany { count, .. } => {
+            PopupMenu::PlaylistTracksRemove { count, .. } => {
                 format!("Remove {} selected track(s)?", count)
             }
             // ---------- Artists ---------- //
@@ -1054,22 +1049,7 @@ impl PopupMenu {
                 }
                 actions
             }
-            PopupMenu::PlaylistTracksRemove { track_name, .. } => vec![
-                PopupAction::new(
-                    format!("Remove {} from playlist?", track_name),
-                    PopupCommand::None,
-                    Style::default().fg(style::Color::Red),
-                    true,
-                ),
-                PopupAction::new(
-                    "Yes".to_string(),
-                    PopupCommand::Yes,
-                    Style::default().fg(style::Color::Red),
-                    true,
-                ),
-                PopupAction::new("No".to_string(), PopupCommand::No, Style::default(), true),
-            ],
-            PopupMenu::PlaylistTracksRemoveMany { count, .. } => vec![
+            PopupMenu::PlaylistTracksRemove { count, .. } => vec![
                 PopupAction::new(
                     format!("Remove {} selected track(s) from playlist?", count),
                     PopupCommand::None,
@@ -2660,8 +2640,8 @@ impl crate::tui::App {
                     }
                     PopupCommand::Delete => {
                         self.popup.current_menu = Some(PopupMenu::PlaylistTracksRemove {
-                            track_name: track.name.clone(),
-                            track_id: track.id.clone(),
+                            count: 1,
+                            keys: vec![Self::playlist_track_key(&track)],
                             playlist_name: self.state.current_playlist.name.clone(),
                             playlist_id: self.state.current_playlist.id.clone(),
                         });
@@ -2705,43 +2685,7 @@ impl crate::tui::App {
                     self.close_popup();
                 }
             }
-            PopupMenu::PlaylistTracksRemove {
-                track_name,
-                track_id,
-                playlist_name,
-                playlist_id,
-            } => match action {
-                PopupCommand::None => {
-                    self.popup.selected.select_next();
-                }
-                PopupCommand::Yes => {
-                    if self
-                        .client
-                        .as_ref()?
-                        .remove_from_playlist(&track_id, &playlist_id)
-                        .await
-                        .is_ok()
-                    {
-                        self.playlist_tracks.retain(|t| t.playlist_item_id != track_id);
-                        self.set_generic_message(
-                            &format!("{} removed", track_name),
-                            &format!("Successfully removed from {}.", playlist_name),
-                        );
-                    } else {
-                        self.set_generic_message(
-                            "Error removing track",
-                            &format!(
-                                "Failed to remove track {} from playlist {}.",
-                                track_name, playlist_name
-                            ),
-                        );
-                    }
-                }
-                _ => {
-                    self.close_popup();
-                }
-            },
-            PopupMenu::PlaylistTracksRemoveMany { keys, .. } => match action {
+            PopupMenu::PlaylistTracksRemove { keys, .. } => match action {
                 PopupCommand::Yes => {
                     self.close_popup();
                     self.remove_playlist_tracks(keys).await;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -309,6 +309,10 @@ pub struct App {
     pub playlist_editing: bool, // this means the playlist has been changed by the user (such as changing track order). Send after ops done for obvious reasons
     pub playlist_edit_item_id: Option<String>,
     pub playlist_edit_origin_index: Option<usize>,
+    /// Select mode in the playlist tracks pane: mark several tracks, then remove them at once.
+    pub playlist_select_mode: bool,
+    /// Tracks currently marked in playlist select mode (playlist entry id, or media id as fallback).
+    pub playlist_selected_items: HashSet<String>,
 
     // dynamic frame bound heights for page up/down
     pub left_list_height: usize,
@@ -648,6 +652,8 @@ impl App {
             playlist_editing: false,
             playlist_edit_item_id: None,
             playlist_edit_origin_index: None,
+            playlist_select_mode: false,
+            playlist_selected_items: HashSet::new(),
 
             // these get overwritten in the first run loop
             left_list_height: 0,


### PR DESCRIPTION
Closes #176

Adds a elect mode to the playlist tracks pane:

- `v` enters/exits select mode (hint shown in the pane footer)
- `space` / `enter` toggle the track under the cursor; selected rows are highlighted and the count is shown in the header instructions
- navigation keys keep working while selecting
- `d` asks for confirmation before removing every selected track from the playlist (single removal already had a confirmation popup; bulk removal now matches that behavior)
- `esc` exits select mode leaving the selection intact

Tracks are identified by playlist entry id (falling back to media id, matching how single-track removal works today). Partial failures are reported with a count of successfully removed tracks.