### PR TITLE
feat: add multiple tracks to a palylist via select  mode

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -22,6 +22,7 @@ use crate::database::extension::{
 use crate::discography::{self, DiscographyView};
 pub(crate) use crate::helpers::{search_ranked_indices, search_ranked_refs};
 use crate::mpv::SeekFlag;
+use crate::select::SelectPane;
 
 pub(crate) use crate::helpers::Selectable;
 use crate::helpers::{normalize_for_search, Searchable};
@@ -584,7 +585,7 @@ impl App {
             return;
         }
 
-        if self.playlist_select_mode {
+        if self.select.is_active_in(SelectPane::PlaylistTracks) {
             // leaving the playlist tracks pane automatically exits select mode
             if self.state.active_tab != ActiveTab::Playlists
                 || self.state.active_section != ActiveSection::Tracks
@@ -3114,7 +3115,7 @@ impl App {
 
     fn begin_playlist_edit(&mut self) {
         if self.playlist_editing
-            || self.playlist_select_mode
+            || self.select.is_active()
             || !self.state.playlist_tracks_search_term.is_empty()
         {
             return;
@@ -3171,7 +3172,7 @@ impl App {
 
     /// Enter or exit playlist select mode, used to remove multiple tracks from a playlist at once.
     pub fn toggle_playlist_select_mode(&mut self) {
-        if self.playlist_select_mode {
+        if self.select.is_active() {
             self.exit_playlist_select_mode();
             return;
         }
@@ -3187,26 +3188,17 @@ impl App {
             return;
         }
 
-        self.playlist_select_mode = true;
-
         // seed the selection with the track under the cursor so Delete alone removes it
-        if self.playlist_selected_items.is_empty() {
-            let key = self.selected_playlist_track().map(Self::playlist_track_key);
-            if let Some(key) = key {
-                if !key.is_empty() {
-                    self.playlist_selected_items.insert(key);
-                }
-            }
-        }
+        let cursor_key = self.selected_playlist_track().map(Self::playlist_track_key);
+        self.select.enter(SelectPane::PlaylistTracks, cursor_key);
         self.dirty = true;
     }
 
     pub fn exit_playlist_select_mode(&mut self) {
-        if !self.playlist_select_mode {
+        if !self.select.is_active() {
             return;
         }
-        self.playlist_select_mode = false;
-        self.playlist_selected_items.clear();
+        self.select.exit();
         self.dirty = true;
     }
 
@@ -3220,7 +3212,7 @@ impl App {
     }
 
     /// Stable key for marking a playlist track in select mode. Prefers the playlist entry id, but
-    /// falls back to the media id, matching how single tracks are removed today.
+    /// falls back to the media id, matching how single tracks are removed.
     pub(crate) fn playlist_track_key(track: &DiscographySong) -> String {
         if track.playlist_item_id.is_empty() {
             track.id.clone()
@@ -3231,24 +3223,19 @@ impl App {
 
     /// Toggle the track under the cursor in/out of the selection (space / enter in select mode).
     pub fn toggle_playlist_selection(&mut self) {
-        if !self.playlist_select_mode {
+        if !self.select.is_active() {
             return;
         }
         let Some(key) = self.selected_playlist_track().map(Self::playlist_track_key) else {
             return;
         };
-        if key.is_empty() {
-            return;
-        }
-        if !self.playlist_selected_items.remove(&key) {
-            self.playlist_selected_items.insert(key);
-        }
+        self.select.toggle(key);
         self.dirty = true;
     }
 
     /// Ask for confirmation before removing every selected track from the current playlist.
     pub fn request_playlist_selection_removal(&mut self) {
-        if !self.playlist_select_mode || self.playlist_selected_items.is_empty() {
+        if !self.select.is_active_in(SelectPane::PlaylistTracks) || self.select.is_empty() {
             return;
         }
         if self.state.current_playlist.id.is_empty() {
@@ -3259,7 +3246,7 @@ impl App {
         self.state.last_section = self.state.active_section;
         self.state.active_section = ActiveSection::Popup;
         self.popup.current_menu = Some(crate::popup::PopupMenu::PlaylistTracksRemove {
-            keys: self.playlist_selected_items.iter().cloned().collect(),
+            keys: self.select.keys(),
             playlist_name: self.state.current_playlist.name.clone(),
             playlist_id: self.state.current_playlist.id.clone(),
         });

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -3370,8 +3370,10 @@ impl App {
         self.popup.global = false;
         self.state.last_section = self.state.active_section;
         self.state.active_section = ActiveSection::Popup;
+        let order: Vec<String> =
+            self.playlist_tracks.iter().map(Self::playlist_track_key).collect();
         self.popup.current_menu = Some(crate::popup::PopupMenu::PlaylistTracksRemove {
-            keys: self.select.keys(),
+            keys: self.select.ordered_keys(&order),
             playlist_name: self.state.current_playlist.name.clone(),
             playlist_id: self.state.current_playlist.id.clone(),
         });

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -7,7 +7,7 @@ Keyboard related functions
 use crate::{
     client::{Album, Artist, DiscographySong},
     database::{
-        database::{Command, DownloadCommand, RemoveCommand},
+        database::{Command, DownloadCommand, RemoveCommand, UpdateCommand},
         extension::DownloadStatus,
     },
     sort,
@@ -3363,6 +3363,22 @@ impl App {
                 !selection.contains(&key)
             });
             self.playlist_track_select_by_index(0);
+
+            self.playlists
+                .iter_mut()
+                .find(|p| p.id == playlist_id)
+                .map(|p| p.child_count = p.child_count.saturating_sub(removed_ok as u64));
+            if self.state.current_playlist.id == playlist_id {
+                self.state.current_playlist.child_count =
+                    self.state.current_playlist.child_count.saturating_sub(removed_ok as u64);
+            }
+
+            let _ = self
+                .db
+                .cmd_tx
+                .send(Command::Update(UpdateCommand::Playlist { playlist_id: playlist_id.clone() }))
+                .await;
+
             self.set_generic_message(
                 "Tracks removed",
                 &format!("Removed {} track(s) from {}.", removed_ok, playlist_name),

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -154,7 +154,7 @@ pub enum Action {
     CollapseAlbum,
     /// Fold every album in the discography pane, or unfold them all
     CollapseAllAlbums,
-    /// Toggle select mode in the playlist tracks pane, to remove multiple tracks at once
+    /// Toggle select mode in the current tracks pane, to act on multiple tracks at once
     ToggleSelectMode,
 }
 
@@ -238,7 +238,7 @@ impl Action {
             Action::Reset => Cow::Borrowed("Reset state"),
             Action::CollapseAlbum => Cow::Borrowed("Fold / unfold selected album"),
             Action::CollapseAllAlbums => Cow::Borrowed("Fold / unfold all albums"),
-            Action::ToggleSelectMode => Cow::Borrowed("Toggle playlist select mode"),
+            Action::ToggleSelectMode => Cow::Borrowed("Toggle select mode"),
         }
     }
 
@@ -585,17 +585,27 @@ impl App {
             return;
         }
 
-        if self.select.is_active_in(SelectPane::PlaylistTracks) {
-            // leaving the playlist tracks pane automatically exits select mode
-            if self.state.active_tab != ActiveTab::Playlists
-                || self.state.active_section != ActiveSection::Tracks
-            {
-                self.exit_playlist_select_mode();
+        if let Some(pane) = self.select.pane() {
+            let (tab, section) = Self::select_location(pane);
+            // leaving the owning pane automatically exits select mode
+            if self.state.active_tab != tab || self.state.active_section != section {
+                self.exit_select_mode();
             } else {
                 match action {
-                    Action::Cancel | Action::ToggleSelectMode => self.exit_playlist_select_mode(),
-                    Action::PlayPause | Action::Enter => self.toggle_playlist_selection(),
-                    Action::Delete => self.request_playlist_selection_removal(),
+                    Action::Cancel | Action::ToggleSelectMode => self.exit_select_mode(),
+                    Action::PlayPause | Action::Enter => self.toggle_select_item(),
+                    Action::Delete => {
+                        if pane == SelectPane::PlaylistTracks {
+                            self.request_playlist_selection_removal();
+                        }
+                    }
+                    Action::Popup => {
+                        if pane == SelectPane::PlaylistTracks {
+                            self.request_popup(false).await;
+                        } else {
+                            self.request_selection_add_to_playlist();
+                        }
+                    }
                     // navigation keeps working while selecting
                     Action::Up => self.select_previous(),
                     Action::Down => self.select_next(),
@@ -608,7 +618,6 @@ impl App {
                     Action::JumpBackward => self.jump_backward(),
                     Action::Quit => self.exit().await,
                     Action::Help => self.show_help(),
-                    Action::Popup => self.request_popup(false).await,
                     Action::GlobalPopup => self.request_popup(true).await,
                     _ => return,
                 }
@@ -691,7 +700,7 @@ impl App {
             Action::Reset => self.reset().await,
             Action::CollapseAlbum => self.toggle_collapse_album(),
             Action::CollapseAllAlbums => self.toggle_all_albums_collapse(),
-            Action::ToggleSelectMode => self.toggle_playlist_select_mode(),
+            Action::ToggleSelectMode => self.toggle_select_mode(),
             Action::ToggleTranscode => self.toggle_transcoding().await,
             Action::Volume(delta) => self.volume_delta(*delta).await,
             Action::Up => self.select_previous(),
@@ -3170,35 +3179,116 @@ impl App {
         self.playlist_edit_origin_index = None;
     }
 
-    /// Enter or exit playlist select mode, used to remove multiple tracks from a playlist at once.
-    pub fn toggle_playlist_select_mode(&mut self) {
-        if self.select.is_active() {
-            self.exit_playlist_select_mode();
-            return;
+    /// Where each select-mode pane lives; sessions exit when the focus leaves this spot.
+    fn select_location(pane: SelectPane) -> (ActiveTab, ActiveSection) {
+        match pane {
+            SelectPane::LibraryTracks => (ActiveTab::Library, ActiveSection::Tracks),
+            SelectPane::AlbumTracks => (ActiveTab::Albums, ActiveSection::Tracks),
+            SelectPane::PlaylistTracks => (ActiveTab::Playlists, ActiveSection::Tracks),
         }
+    }
 
-        // select mode only makes sense in the playlist tracks pane
-        if self.client.is_none()
-            || self.playlist_editing
-            || self.playlist_incomplete
-            || self.playlist_stale
-            || self.state.active_tab != ActiveTab::Playlists
-            || self.state.active_section != ActiveSection::Tracks
-        {
-            return;
+    /// The pane `v` would enter here, or `None` when there is nothing selectable.
+    fn select_target_pane(&self) -> Option<SelectPane> {
+        match (self.state.active_tab, self.state.active_section) {
+            (ActiveTab::Playlists, ActiveSection::Tracks) => {
+                if self.client.is_some()
+                    && !self.playlist_editing
+                    && !self.playlist_incomplete
+                    && !self.playlist_stale
+                {
+                    Some(SelectPane::PlaylistTracks)
+                } else {
+                    None
+                }
+            }
+            (ActiveTab::Library, ActiveSection::Tracks) => {
+                if self.client.is_some() && !self.tracks.is_empty() {
+                    Some(SelectPane::LibraryTracks)
+                } else {
+                    None
+                }
+            }
+            (ActiveTab::Albums, ActiveSection::Tracks) => {
+                if self.client.is_some() && !self.album_tracks.is_empty() {
+                    Some(SelectPane::AlbumTracks)
+                } else {
+                    None
+                }
+            }
+            _ => None,
         }
+    }
 
-        // seed the selection with the track under the cursor so Delete alone removes it
-        let cursor_key = self.selected_playlist_track().map(Self::playlist_track_key);
-        self.select.enter(SelectPane::PlaylistTracks, cursor_key);
+    /// The key under the cursor for the given pane; headers and empty lists give `None`.
+    fn select_key_under_cursor(&self, pane: SelectPane) -> Option<String> {
+        match pane {
+            SelectPane::PlaylistTracks => {
+                self.selected_playlist_track().map(Self::playlist_track_key)
+            }
+            SelectPane::LibraryTracks => {
+                let row = self.state.selected_track.selected().unwrap_or(0);
+                let track = self.track_view().track(&self.tracks, row)?;
+                if track.is_album_header() {
+                    None
+                } else {
+                    Some(track.id.clone())
+                }
+            }
+            SelectPane::AlbumTracks => {
+                let key = self.get_id_of_selected(&self.album_tracks, Selectable::AlbumTrack);
+                if key.is_empty() {
+                    None
+                } else {
+                    Some(key)
+                }
+            }
+        }
+    }
+
+    /// Enter or exit select mode in the current pane. Pressing `v` somewhere else while a session
+    /// is active steals the session; pressing it back in that pane exits it.
+    pub fn toggle_select_mode(&mut self) {
+        let target = self.select_target_pane();
+        match (self.select.pane(), target) {
+            (None, None) => {}
+            (Some(_), None) => self.exit_select_mode(),
+            (None, Some(pane)) => self.enter_select_mode(pane),
+            (Some(active), Some(target)) => {
+                if active == target {
+                    self.exit_select_mode();
+                } else {
+                    self.enter_select_mode(target);
+                }
+            }
+        }
+    }
+
+    fn enter_select_mode(&mut self, pane: SelectPane) {
+        // seed the selection with the item under the cursor
+        let cursor_key = self.select_key_under_cursor(pane);
+        self.select.enter(pane, cursor_key);
         self.dirty = true;
     }
 
-    pub fn exit_playlist_select_mode(&mut self) {
+    pub fn exit_select_mode(&mut self) {
         if !self.select.is_active() {
             return;
         }
         self.select.exit();
+        self.dirty = true;
+    }
+
+    /// Toggle the item under the cursor in/out of the selection (space / enter in select mode).
+    pub fn toggle_select_item(&mut self) {
+        let pane = match self.select.pane() {
+            Some(pane) => pane,
+            None => return,
+        };
+        let Some(key) = self.select_key_under_cursor(pane) else {
+            return;
+        };
+        self.select.toggle(key);
         self.dirty = true;
     }
 
@@ -3219,18 +3309,6 @@ impl App {
         } else {
             track.playlist_item_id.clone()
         }
-    }
-
-    /// Toggle the track under the cursor in/out of the selection (space / enter in select mode).
-    pub fn toggle_playlist_selection(&mut self) {
-        if !self.select.is_active() {
-            return;
-        }
-        let Some(key) = self.selected_playlist_track().map(Self::playlist_track_key) else {
-            return;
-        };
-        self.select.toggle(key);
-        self.dirty = true;
     }
 
     /// Ask for confirmation before removing every selected track from the current playlist.
@@ -3296,7 +3374,7 @@ impl App {
             );
         }
 
-        self.exit_playlist_select_mode();
+        self.exit_select_mode();
     }
 
     async fn global_search(&mut self) {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -590,39 +590,86 @@ impl App {
             // leaving the owning pane automatically exits select mode
             if self.state.active_tab != tab || self.state.active_section != section {
                 self.exit_select_mode();
+                return;
             } else {
                 match action {
-                    Action::Cancel | Action::ToggleSelectMode => self.exit_select_mode(),
-                    Action::PlayPause | Action::Enter => self.toggle_select_item(),
+                    Action::Cancel | Action::ToggleSelectMode => {
+                        self.exit_select_mode();
+                        return;
+                    }
+                    Action::PlayPause | Action::Enter => {
+                        self.toggle_select_item();
+                        return;
+                    }
                     Action::Delete => {
                         if pane == SelectPane::PlaylistTracks {
                             self.request_playlist_selection_removal();
                         }
+                        return;
                     }
+                    Action::MoveItemUp | Action::MoveItemDown => return,
                     Action::Popup => {
                         if pane == SelectPane::PlaylistTracks {
                             self.request_popup(false).await;
                         } else {
                             self.request_selection_add_to_playlist();
                         }
+                        return;
                     }
                     // navigation keeps working while selecting
-                    Action::Up => self.select_previous(),
-                    Action::Down => self.select_next(),
-                    Action::Jump(lines) => self.jump(*lines),
-                    Action::PageUp => self.page_up(),
-                    Action::PageDown => self.page_down(),
-                    Action::JumpFirst => self.go_first(),
-                    Action::JumpLast => self.go_last(),
-                    Action::JumpForward => self.jump_forward(),
-                    Action::JumpBackward => self.jump_backward(),
-                    Action::Quit => self.exit().await,
-                    Action::Help => self.show_help(),
-                    Action::GlobalPopup => self.request_popup(true).await,
-                    _ => return,
+                    Action::Up => {
+                        self.select_previous();
+                        return;
+                    }
+                    Action::Down => {
+                        self.select_next();
+                        return;
+                    }
+                    Action::Jump(lines) => {
+                        self.jump(*lines);
+                        return;
+                    }
+                    Action::PageUp => {
+                        self.page_up();
+                        return;
+                    }
+                    Action::PageDown => {
+                        self.page_down();
+                        return;
+                    }
+                    Action::JumpFirst => {
+                        self.go_first();
+                        return;
+                    }
+                    Action::JumpLast => {
+                        self.go_last();
+                        return;
+                    }
+                    Action::JumpForward => {
+                        self.jump_forward();
+                        return;
+                    }
+                    Action::JumpBackward => {
+                        self.jump_backward();
+                        return;
+                    }
+                    Action::Quit => {
+                        self.exit().await;
+                        return;
+                    }
+                    Action::Help => {
+                        self.show_help();
+                        return;
+                    }
+                    Action::GlobalPopup => {
+                        self.request_popup(true).await;
+                        return;
+                    }
+                    // everything else (e.g. CollapseAlbum) falls
+                    // through to the normal keymap below
+                    _ => {}
                 }
             }
-            return;
         }
 
         if self.zen_mode {

--- a/src/library.rs
+++ b/src/library.rs
@@ -12,6 +12,7 @@ Main Library tab
 -------------------------- */
 
 use crate::database::extension::DownloadStatus;
+use crate::select::SelectPane;
 use crate::tui::App;
 use crate::{helpers, keyboard::*};
 
@@ -1069,14 +1070,20 @@ impl App {
                     title.push(Span::styled(&track.name[last_end..], Style::default().fg(color)));
                 }
 
+                let is_selected = self.select.is_active_in(SelectPane::LibraryTracks)
+                    && self.select.is_selected(&track.id);
+
                 let mut cells: Vec<Cell> = vec![
-                    Cell::from(format!("{}.", track.index_number)).style(
-                        if track.id == self.active_song_id {
-                            Style::default().fg(color)
-                        } else {
-                            Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
-                        },
-                    ),
+                    Cell::from(if is_selected {
+                        format!("✓{}.", track.index_number)
+                    } else {
+                        format!("{}.", track.index_number)
+                    })
+                    .style(if track.id == self.active_song_id {
+                        Style::default().fg(color)
+                    } else {
+                        Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
+                    }),
                     Cell::from(if all_subsequences.is_empty() {
                         title_str.into()
                     } else {
@@ -1135,7 +1142,11 @@ impl App {
                 max_duration_len = std::cmp::max(max_duration_len, duration_str.len());
                 cells.push(Cell::from(Text::from(duration_str).alignment(Alignment::Right)));
 
-                let style = if track.id == self.active_song_id {
+                let style = if is_selected {
+                    Style::default()
+                        .fg(self.theme.primary_color)
+                        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+                } else if track.id == self.active_song_id {
                     Style::default().fg(self.theme.primary_color).italic()
                 } else if track.disliked {
                     Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
@@ -1147,14 +1158,45 @@ impl App {
             })
             .collect::<Vec<Row>>();
 
-        let track_instructions = Line::from(vec![
-            " Help ".fg(self.theme.resolve(&self.theme.section_title)),
-            "<?>".fg(self.theme.primary_color).bold(),
-            " Quit ".fg(self.theme.resolve(&self.theme.section_title)),
-            "<^C> ".fg(self.theme.primary_color).bold(),
-        ]);
+        let track_instructions = if self.select.is_active_in(SelectPane::LibraryTracks) {
+            Line::from(vec![
+                Span::styled(
+                    format!(" {} selected ", self.select.len()),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Toggle ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<space>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Add to playlist ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<p>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Exit ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<esc>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+            ])
+        } else {
+            let mut line = vec![
+                " Help ".fg(self.theme.resolve(&self.theme.section_title)),
+                "<?>".fg(self.theme.primary_color).bold(),
+            ];
+            if self.client.is_some() {
+                line.push(" Select ".fg(self.theme.resolve(&self.theme.section_title)));
+                line.push("<V>".fg(self.theme.primary_color).bold());
+            }
+            line.push(" Quit ".fg(self.theme.resolve(&self.theme.section_title)));
+            line.push("<^C> ".fg(self.theme.primary_color).bold());
+            Line::from(line)
+        };
 
-        let mut widths: Vec<Constraint> = vec![Constraint::Length(4)];
+        let mut widths: Vec<Constraint> = vec![Constraint::Length(
+            4 + if self.select.is_active_in(SelectPane::LibraryTracks) { 1 } else { 0 },
+        )];
         if show_album_column {
             widths.push(Constraint::Percentage(70)); // Title
             widths.push(Constraint::Percentage(30)); // Album
@@ -1366,14 +1408,20 @@ impl App {
                     title.push(Span::styled(&track.name[last_end..], Style::default().fg(color)));
                 }
 
+                let is_selected = self.select.is_active_in(SelectPane::AlbumTracks)
+                    && self.select.is_selected(&track.id);
+
                 let mut cells: Vec<Cell> = vec![
-                    Cell::from(format!("{}.", track.index_number)).style(
-                        if track.id == self.active_song_id {
-                            Style::default().fg(color)
-                        } else {
-                            Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
-                        },
-                    ),
+                    Cell::from(if is_selected {
+                        format!("✓{}.", track.index_number)
+                    } else {
+                        format!("{}.", track.index_number)
+                    })
+                    .style(if track.id == self.active_song_id {
+                        Style::default().fg(color)
+                    } else {
+                        Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
+                    }),
                     Cell::from(if all_subsequences.is_empty() {
                         track.name.to_string().into()
                     } else {
@@ -1429,7 +1477,11 @@ impl App {
                         .alignment(Alignment::Right),
                 ));
 
-                Row::new(cells).style(if track.id == self.active_song_id {
+                Row::new(cells).style(if is_selected {
+                    Style::default()
+                        .fg(self.theme.primary_color)
+                        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+                } else if track.id == self.active_song_id {
                     Style::default().fg(self.theme.primary_color).italic()
                 } else if track.disliked {
                     Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
@@ -1439,15 +1491,48 @@ impl App {
             })
             .collect::<Vec<Row>>();
 
-        let track_instructions = Line::from(vec![
-            " Help ".fg(self.theme.resolve(&self.theme.section_title)),
-            "<?>".fg(self.theme.primary_color).bold(),
-            " Quit ".fg(self.theme.resolve(&self.theme.section_title)),
-            "<^C> ".fg(self.theme.primary_color).bold(),
-        ]);
+        let track_instructions = if self.select.is_active_in(SelectPane::AlbumTracks) {
+            Line::from(vec![
+                Span::styled(
+                    format!(" {} selected ", self.select.len()),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Toggle ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<space>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Add to playlist ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<p>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Exit ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<esc>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+            ])
+        } else {
+            let mut line = vec![
+                " Help ".fg(self.theme.resolve(&self.theme.section_title)),
+                "<?>".fg(self.theme.primary_color).bold(),
+            ];
+            if self.client.is_some() {
+                line.push(" Select ".fg(self.theme.resolve(&self.theme.section_title)));
+                line.push("<V>".fg(self.theme.primary_color).bold());
+            }
+            line.push(" Quit ".fg(self.theme.resolve(&self.theme.section_title)));
+            line.push("<^C> ".fg(self.theme.primary_color).bold());
+            Line::from(line)
+        };
 
         let mut widths: Vec<Constraint> = vec![
-            Constraint::Length(items.len().to_string().len() as u16 + 2),
+            Constraint::Length(
+                items.len().to_string().len() as u16
+                    + 2
+                    + if self.select.is_active_in(SelectPane::AlbumTracks) { 1 } else { 0 },
+            ),
             Constraint::Percentage(100),
         ];
         if show_disc {

--- a/src/library.rs
+++ b/src/library.rs
@@ -1158,41 +1158,7 @@ impl App {
             })
             .collect::<Vec<Row>>();
 
-        let track_instructions = if self.select.is_active_in(SelectPane::LibraryTracks) {
-            Line::from(vec![
-                Span::styled(
-                    format!(" {} selected ", self.select.len()),
-                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
-                ),
-                " Toggle ".fg(self.theme.resolve(&self.theme.section_title)),
-                Span::styled(
-                    "<space>".to_string(),
-                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
-                ),
-                " Add to playlist ".fg(self.theme.resolve(&self.theme.section_title)),
-                Span::styled(
-                    "<p>".to_string(),
-                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
-                ),
-                " Exit ".fg(self.theme.resolve(&self.theme.section_title)),
-                Span::styled(
-                    "<esc>".to_string(),
-                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
-                ),
-            ])
-        } else {
-            let mut line = vec![
-                " Help ".fg(self.theme.resolve(&self.theme.section_title)),
-                "<?>".fg(self.theme.primary_color).bold(),
-            ];
-            if self.client.is_some() {
-                line.push(" Select ".fg(self.theme.resolve(&self.theme.section_title)));
-                line.push("<V>".fg(self.theme.primary_color).bold());
-            }
-            line.push(" Quit ".fg(self.theme.resolve(&self.theme.section_title)));
-            line.push("<^C> ".fg(self.theme.primary_color).bold());
-            Line::from(line)
-        };
+        let track_instructions = self.track_select_instructions(SelectPane::LibraryTracks);
 
         let mut widths: Vec<Constraint> = vec![Constraint::Length(
             4 + if self.select.is_active_in(SelectPane::LibraryTracks) { 1 } else { 0 },
@@ -1491,41 +1457,7 @@ impl App {
             })
             .collect::<Vec<Row>>();
 
-        let track_instructions = if self.select.is_active_in(SelectPane::AlbumTracks) {
-            Line::from(vec![
-                Span::styled(
-                    format!(" {} selected ", self.select.len()),
-                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
-                ),
-                " Toggle ".fg(self.theme.resolve(&self.theme.section_title)),
-                Span::styled(
-                    "<space>".to_string(),
-                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
-                ),
-                " Add to playlist ".fg(self.theme.resolve(&self.theme.section_title)),
-                Span::styled(
-                    "<p>".to_string(),
-                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
-                ),
-                " Exit ".fg(self.theme.resolve(&self.theme.section_title)),
-                Span::styled(
-                    "<esc>".to_string(),
-                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
-                ),
-            ])
-        } else {
-            let mut line = vec![
-                " Help ".fg(self.theme.resolve(&self.theme.section_title)),
-                "<?>".fg(self.theme.primary_color).bold(),
-            ];
-            if self.client.is_some() {
-                line.push(" Select ".fg(self.theme.resolve(&self.theme.section_title)));
-                line.push("<V>".fg(self.theme.primary_color).bold());
-            }
-            line.push(" Quit ".fg(self.theme.resolve(&self.theme.section_title)));
-            line.push("<^C> ".fg(self.theme.primary_color).bold());
-            Line::from(line)
-        };
+        let track_instructions = self.track_select_instructions(SelectPane::AlbumTracks);
 
         let mut widths: Vec<Constraint> = vec![
             Constraint::Length(
@@ -1676,6 +1608,44 @@ impl App {
 
         frame.render_widget(Clear, center[0]);
         frame.render_stateful_widget(table, center[0], &mut self.state.selected_album_track);
+    }
+
+    fn track_select_instructions<'a>(&self, pane: SelectPane) -> Line<'a> {
+        if self.select.is_active_in(pane) {
+            Line::from(vec![
+                Span::styled(
+                    format!(" {} selected ", self.select.len()),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Toggle ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<space>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Add to playlist ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<p>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+                " Exit ".fg(self.theme.resolve(&self.theme.section_title)),
+                Span::styled(
+                    "<esc>".to_string(),
+                    Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
+                ),
+            ])
+        } else {
+            let mut line = vec![
+                " Help ".fg(self.theme.resolve(&self.theme.section_title)),
+                "<?>".fg(self.theme.primary_color).bold(),
+            ];
+            if self.client.is_some() {
+                line.push(" Select ".fg(self.theme.resolve(&self.theme.section_title)));
+                line.push("<V>".fg(self.theme.primary_color).bold());
+            }
+            line.push(" Quit ".fg(self.theme.resolve(&self.theme.section_title)));
+            line.push("<^C> ".fg(self.theme.primary_color).bold());
+            Line::from(line)
+        }
     }
 
     pub fn render_player(

--- a/src/library.rs
+++ b/src/library.rs
@@ -978,13 +978,19 @@ impl App {
                             _ => "",
                         };
 
-                    // a folded album hides the now-playing highlight, so surface it on the header
+                    // a folded album hides the now-playing highlight, so surface it on the header.
+                    // Albums are never selectable themselves, so the header doesn't change;
+                    // we add a ✓ when any of its tracks is checked (collapsed or not).
                     let plays_hidden_current = self.collapsed_albums.contains(&album_id)
                         && self
                             .state
                             .queue
                             .get(self.state.current_playback_state.current_index)
                             .is_some_and(|s| s.album_id == album_id);
+                    let has_selected = self.select.is_active_in(SelectPane::LibraryTracks)
+                        && crate::discography::album_tracks(&self.tracks, &album_id)
+                            .iter()
+                            .any(|t| self.select.is_selected(&t.id));
                     let header_fg = if plays_hidden_current {
                         self.theme.primary_color
                     } else {
@@ -999,9 +1005,13 @@ impl App {
                             String::new()
                         })
                         .style(Style::default().fg(header_fg)),
-                        Cell::from(title_str)
-                            .column_span(if show_album_column { 2 } else { 1 })
-                            .fg(header_fg),
+                        Cell::from(if has_selected {
+                            format!("✓ {}", title_str)
+                        } else {
+                            title_str
+                        })
+                        .column_span(if show_album_column { 2 } else { 1 })
+                        .fg(header_fg),
                     ];
                     if show_disc {
                         cells.push(Cell::from(""));
@@ -1070,19 +1080,23 @@ impl App {
                     title.push(Span::styled(&track.name[last_end..], Style::default().fg(color)));
                 }
 
-                let is_selected = self.select.is_active_in(SelectPane::LibraryTracks)
-                    && self.select.is_selected(&track.id);
+                let select_mode = self.select.is_active_in(SelectPane::LibraryTracks);
+                let is_selected = select_mode && self.select.is_selected(&track.id);
 
                 let mut cells: Vec<Cell> = vec![
-                    Cell::from(if is_selected {
-                        format!("✓{}.", track.index_number)
+                    // No. - the ✓ slot is reserved for every row in select mode, so toggling a
+                    // track doesn't shift the numbers under the cursor
+                    Cell::from(if select_mode {
+                        format!("{}{}.", if is_selected { "✓" } else { " " }, track.index_number)
                     } else {
                         format!("{}.", track.index_number)
                     })
-                    .style(if track.id == self.active_song_id {
+                    .style(if is_selected {
+                        Style::default().fg(self.theme.resolve(&self.theme.foreground))
+                    } else if track.id == self.active_song_id {
                         Style::default().fg(color)
                     } else {
-                        Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
+                        Style::default().fg(Color::DarkGray)
                     }),
                     Cell::from(if all_subsequences.is_empty() {
                         title_str.into()
@@ -1115,14 +1129,20 @@ impl App {
                     }));
                 }
 
-                // ♥ (favorite)
+                // ♥ (favorite) - dims along with the rest of the row it sits on
                 cells.push(
                     Cell::from(if track.user_data.is_favorite {
                         &self.symbols.favorite
                     } else {
                         ""
                     })
-                    .style(Style::default().fg(self.theme.primary_color)),
+                    .style(Style::default().fg(
+                        if select_mode && !is_selected {
+                            self.theme.resolve(&self.theme.foreground_dim)
+                        } else {
+                            self.theme.primary_color
+                        },
+                    )),
                 );
 
                 // ♪
@@ -1142,7 +1162,7 @@ impl App {
                 max_duration_len = std::cmp::max(max_duration_len, duration_str.len());
                 cells.push(Cell::from(Text::from(duration_str).alignment(Alignment::Right)));
 
-                let style = if is_selected {
+                let mut style = if is_selected {
                     Style::default()
                         .fg(self.theme.primary_color)
                         .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
@@ -1153,6 +1173,9 @@ impl App {
                 } else {
                     Style::default().fg(self.theme.resolve(&self.theme.foreground))
                 };
+                if select_mode && !is_selected {
+                    style = style.fg(self.theme.resolve(&self.theme.foreground_dim));
+                }
 
                 Row::new(cells).style(style)
             })
@@ -1234,8 +1257,16 @@ impl App {
 
         let selected_is_album = tracks.get(selection).map_or(false, |t| t.is_album_header());
 
-        let mut header_cells: Vec<&str> =
-            vec![if selected_is_album { "Yr." } else { "No." }, "Title"];
+        let mut header_cells: Vec<&str> = vec![
+            if selected_is_album {
+                "Yr."
+            } else if self.select.is_active_in(SelectPane::LibraryTracks) {
+                " No."
+            } else {
+                "No."
+            },
+            "Title",
+        ];
         if show_album_column {
             header_cells.push("Album");
         }
@@ -1374,19 +1405,23 @@ impl App {
                     title.push(Span::styled(&track.name[last_end..], Style::default().fg(color)));
                 }
 
-                let is_selected = self.select.is_active_in(SelectPane::AlbumTracks)
-                    && self.select.is_selected(&track.id);
+                let select_mode = self.select.is_active_in(SelectPane::AlbumTracks);
+                let is_selected = select_mode && self.select.is_selected(&track.id);
 
                 let mut cells: Vec<Cell> = vec![
-                    Cell::from(if is_selected {
-                        format!("✓{}.", track.index_number)
+                    // No. - the ✓ slot is reserved for every row in select mode, so toggling a
+                    // track doesn't shift the numbers under the cursor
+                    Cell::from(if select_mode {
+                        format!("{}{}.", if is_selected { "✓" } else { " " }, track.index_number)
                     } else {
                         format!("{}.", track.index_number)
                     })
-                    .style(if track.id == self.active_song_id {
+                    .style(if is_selected {
+                        Style::default().fg(self.theme.resolve(&self.theme.foreground))
+                    } else if track.id == self.active_song_id {
                         Style::default().fg(color)
                     } else {
-                        Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
+                        Style::default().fg(Color::DarkGray)
                     }),
                     Cell::from(if all_subsequences.is_empty() {
                         track.name.to_string().into()
@@ -1415,14 +1450,20 @@ impl App {
                     }));
                 }
 
-                // ♥
+                // ♥ - dims along with the rest of the row it sits on
                 cells.push(
                     Cell::from(if track.user_data.is_favorite {
                         &self.symbols.favorite
                     } else {
                         ""
                     })
-                    .style(Style::default().fg(self.theme.primary_color)),
+                    .style(Style::default().fg(
+                        if select_mode && !is_selected {
+                            self.theme.resolve(&self.theme.foreground_dim)
+                        } else {
+                            self.theme.primary_color
+                        },
+                    )),
                 );
 
                 // ♪
@@ -1443,7 +1484,7 @@ impl App {
                         .alignment(Alignment::Right),
                 ));
 
-                Row::new(cells).style(if is_selected {
+                let mut row_style = if is_selected {
                     Style::default()
                         .fg(self.theme.primary_color)
                         .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
@@ -1453,7 +1494,12 @@ impl App {
                     Style::default().fg(self.theme.resolve(&self.theme.foreground_dim))
                 } else {
                     Style::default().fg(self.theme.resolve(&self.theme.foreground))
-                })
+                };
+                if select_mode && !is_selected {
+                    row_style = row_style.fg(self.theme.resolve(&self.theme.foreground_dim));
+                }
+
+                Row::new(cells).style(row_style)
             })
             .collect::<Vec<Row>>();
 
@@ -1529,7 +1575,10 @@ impl App {
         };
         let duration = format!("{}{:02}:{:02}", hours_optional_text, minutes, seconds);
 
-        let mut header_cells: Vec<&str> = vec!["No.", "Title"];
+        let mut header_cells: Vec<&str> = vec![
+            if self.select.is_active_in(SelectPane::AlbumTracks) { " No." } else { "No." },
+            "Title",
+        ];
         if show_disc {
             header_cells.push(&self.symbols.disc);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod playlists;
 mod popup;
 mod queue;
 mod search;
+mod select;
 mod sort;
 #[cfg(test)]
 mod tests;

--- a/src/playlists.rs
+++ b/src/playlists.rs
@@ -3,6 +3,7 @@ The playlists tab is rendered here.
 -------------------------- */
 
 use crate::keyboard::*;
+use crate::select::SelectPane;
 use crate::tui::App;
 use crate::{database::extension::DownloadStatus, helpers};
 
@@ -225,8 +226,9 @@ impl App {
                 {
                     return Row::default();
                 }
-                let is_selected = self.playlist_select_mode
-                    && self.playlist_selected_items.contains(&Self::playlist_track_key(track));
+                let select_mode = self.select.is_active_in(SelectPane::PlaylistTracks);
+                let is_selected =
+                    select_mode && self.select.is_selected(&Self::playlist_track_key(track));
                 // track.run_time_ticks is in microseconds
                 let seconds = (track.run_time_ticks / 10_000_000) % 60;
                 let minutes = (track.run_time_ticks / 10_000_000 / 60) % 60;
@@ -273,7 +275,7 @@ impl App {
                 let mut cells = vec![
                     // No. - the ✓ slot is reserved for every row in select mode, so toggling a
                     // track doesn't shift the numbers under the cursor
-                    Cell::from(if self.playlist_select_mode {
+                    Cell::from(if select_mode {
                         format!("{}{}.", if is_selected { "✓" } else { " " }, i + 1)
                     } else {
                         format!("{}.", i + 1)
@@ -314,7 +316,7 @@ impl App {
                         ""
                     })
                     .style(Style::default().fg(
-                        if self.playlist_select_mode && !is_selected {
+                        if select_mode && !is_selected {
                             self.theme.resolve(&self.theme.foreground_dim)
                         } else {
                             self.theme.primary_color
@@ -342,7 +344,7 @@ impl App {
                 } else {
                     Style::default().fg(self.theme.resolve(&self.theme.foreground))
                 };
-                if self.playlist_select_mode && !is_selected {
+                if select_mode && !is_selected {
                     row_style = row_style.fg(self.theme.resolve(&self.theme.foreground_dim));
                 }
 
@@ -350,10 +352,10 @@ impl App {
             })
             .collect::<Vec<Row>>();
 
-        let track_instructions = if self.playlist_select_mode {
+        let track_instructions = if self.select.is_active_in(SelectPane::PlaylistTracks) {
             Line::from(vec![
                 Span::styled(
-                    format!(" {} selected ", self.playlist_selected_items.len()),
+                    format!(" {} selected ", self.select.len()),
                     Style::default().fg(self.theme.primary_color).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
@@ -407,7 +409,7 @@ impl App {
             Constraint::Length(
                 items.len().to_string().len() as u16
                     + 2
-                    + if self.playlist_select_mode { 1 } else { 0 },
+                    + if self.select.is_active_in(SelectPane::PlaylistTracks) { 1 } else { 0 },
             ),
             Constraint::Percentage(50), // title and track even width
             Constraint::Percentage(25),
@@ -467,7 +469,7 @@ impl App {
             let duration = format!("{}{:02}:{:02}", hours_optional_text, minutes, seconds);
 
             let mut header_cells = vec![
-                if self.playlist_select_mode { " No." } else { "No." },
+                if self.select.is_active_in(SelectPane::PlaylistTracks) { " No." } else { "No." },
                 "Title",
                 "Artist",
                 "Album",

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -2562,14 +2562,17 @@ impl crate::tui::App {
                         self.copy_lastfm_album_url(&track)?;
                     }
                     PopupCommand::Delete => {
-                        let keys: Vec<String> =
-                            if self.select.is_active_in(crate::select::SelectPane::PlaylistTracks)
-                                && !self.select.is_empty()
-                            {
-                                self.select.keys()
-                            } else {
-                                vec![Self::playlist_track_key(&track)]
-                            };
+                        let keys: Vec<String> = if self
+                            .select
+                            .is_active_in(crate::select::SelectPane::PlaylistTracks)
+                            && !self.select.is_empty()
+                        {
+                            let order: Vec<String> =
+                                self.playlist_tracks.iter().map(Self::playlist_track_key).collect();
+                            self.select.ordered_keys(&order)
+                        } else {
+                            vec![Self::playlist_track_key(&track)]
+                        };
                         self.popup.current_menu = Some(PopupMenu::PlaylistTracksRemove {
                             keys,
                             playlist_name: self.state.current_playlist.name.clone(),
@@ -3075,16 +3078,33 @@ impl crate::tui::App {
     }
 
     /// Open the playlist picker for the current select-mode selection (Library / Albums panes).
+    /// Track ids are ordered to match the source list so the playlist keeps album order.
     pub fn request_selection_add_to_playlist(&mut self) {
         if self.select.is_empty() {
             return;
         }
+        let track_ids = match self.select.pane() {
+            Some(crate::select::SelectPane::LibraryTracks) => {
+                let order: Vec<String> = self
+                    .tracks
+                    .iter()
+                    .filter(|t| !t.is_album_header())
+                    .map(|t| t.id.clone())
+                    .collect();
+                self.select.ordered_keys(&order)
+            }
+            Some(crate::select::SelectPane::AlbumTracks) => {
+                let order: Vec<String> = self.album_tracks.iter().map(|t| t.id.clone()).collect();
+                self.select.ordered_keys(&order)
+            }
+            _ => self.select.keys(),
+        };
         self.popup.global = false;
         self.state.last_section = self.state.active_section;
         self.state.active_section = ActiveSection::Popup;
         self.popup.current_menu = Some(PopupMenu::TracksAddToPlaylist {
-            count: self.select.len(),
-            track_ids: self.select.keys(),
+            count: track_ids.len(),
+            track_ids,
             playlists: self.playlists.clone(),
         });
         self.popup.selected.select_first();

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -178,6 +178,12 @@ pub enum PopupMenu {
         track_id: String,
         playlists: Vec<Playlist>,
     },
+    // Playlist picker for adding every track marked in select mode (Library / Albums panes)
+    TracksAddToPlaylist {
+        count: usize,
+        track_ids: Vec<String>,
+        playlists: Vec<Playlist>,
+    },
     // Confirmation for removing one or many tracks from a playlist; also used when
     // removing a selection marked with select mode (`v`)
     PlaylistTracksRemove {
@@ -338,6 +344,9 @@ impl PopupMenu {
             // ---------- Playlist tracks ---------- //
             PopupMenu::PlaylistTracksRoot { track, .. } => track.name.to_string(),
             PopupMenu::PlaylistTrackAddToPlaylist { track_name, .. } => track_name.to_string(),
+            PopupMenu::TracksAddToPlaylist { count, .. } => {
+                format!("{} selected tracks", count)
+            }
             PopupMenu::PlaylistTracksRemove { keys, .. } => {
                 format!("Remove {} selected track(s)?", keys.len())
             }
@@ -903,27 +912,7 @@ impl PopupMenu {
                 Style::default(),
                 true,
             )],
-            PopupMenu::TrackAddToPlaylist { playlists, .. } => {
-                let mut actions = vec![];
-                for playlist in playlists {
-                    actions.push(PopupAction::new(
-                        format!(
-                            "{}{} ({})",
-                            if playlist.user_data.is_favorite {
-                                format!("{} ", favorite)
-                            } else {
-                                String::new()
-                            },
-                            playlist.name,
-                            playlist.child_count
-                        ),
-                        PopupCommand::AddToPlaylist { playlist_id: playlist.id.clone() },
-                        Style::default(),
-                        true,
-                    ));
-                }
-                actions
-            }
+
             PopupMenu::TrackAlbumsChangeSort {} => vec![
                 PopupAction::new(
                     "Release date - Ascending".to_string(),
@@ -1027,7 +1016,9 @@ impl PopupMenu {
                     true,
                 ),
             ],
-            PopupMenu::PlaylistTrackAddToPlaylist { playlists, .. } => {
+            PopupMenu::TrackAddToPlaylist { playlists, .. }
+            | PopupMenu::PlaylistTrackAddToPlaylist { playlists, .. }
+            | PopupMenu::TracksAddToPlaylist { playlists, .. } => {
                 let mut actions = vec![];
                 for playlist in playlists {
                     actions.push(PopupAction::new(
@@ -1552,9 +1543,8 @@ impl crate::tui::App {
 
     // Apply the Enter key action
     async fn apply_action(&mut self) {
-        let m = self.popup.current_menu.as_ref();
-        let menu = match m {
-            Some(menu) => menu,
+        let menu = match self.popup.current_menu.as_ref() {
+            Some(menu) => menu.clone(),
             None => return,
         };
 
@@ -1585,6 +1575,10 @@ impl crate::tui::App {
             if let PopupCommand::Ok = action {
                 self.close_popup();
             }
+            return;
+        }
+
+        if self.handle_add_to_playlist_action(&action, &menu).await {
             return;
         }
 
@@ -1639,10 +1633,6 @@ impl crate::tui::App {
         action: &PopupCommand,
         menu: PopupMenu,
     ) -> Option<()> {
-        if matches!(&menu, PopupMenu::TrackAddToPlaylist { .. }) {
-            return self.apply_track_action(action, menu).await;
-        }
-
         match menu {
             PopupMenu::QueueTrackRoot { track_name, track_id } => match action {
                 PopupCommand::AddToPlaylist { .. } => {
@@ -2183,38 +2173,7 @@ impl crate::tui::App {
                     self.close_popup();
                 }
             },
-            PopupMenu::TrackAddToPlaylist { track_name, track_id, playlists } => match action {
-                PopupCommand::AddToPlaylist { playlist_id } => {
-                    let playlist = playlists.iter().find(|p| p.id == *playlist_id)?;
-                    if let Err(_) =
-                        self.client.as_ref()?.add_to_playlist(&track_id, playlist_id).await
-                    {
-                        self.set_generic_message(
-                            "Error adding track",
-                            &format!(
-                                "Failed to add track {} to playlist {}.",
-                                track_name, playlist.name
-                            ),
-                        );
-                        return Some(());
-                    }
-                    self.playlists
-                        .iter_mut()
-                        .find(|p| p.id == playlist.id)
-                        .map(|p| p.child_count += 1);
 
-                    self.set_generic_message(
-                        "Track added",
-                        &format!(
-                            "Track {} successfully added to playlist {}.",
-                            track_name, playlist.name
-                        ),
-                    );
-                }
-                _ => {
-                    self.close_popup();
-                }
-            },
             PopupMenu::TrackAlbumsChangeSort {} => {
                 match action {
                     PopupCommand::Ascending => {
@@ -2532,42 +2491,7 @@ impl crate::tui::App {
                     _ => {}
                 }
             }
-            PopupMenu::TrackAddToPlaylist { track_name, track_id, playlists } => match action {
-                PopupCommand::AddToPlaylist { playlist_id } => {
-                    let playlist = playlists.iter().find(|p| p.id == *playlist_id)?;
-                    if self
-                        .client
-                        .as_ref()?
-                        .add_to_playlist(&track_id, playlist_id)
-                        .await
-                        .log_err("add to playlist")
-                        .is_err()
-                    {
-                        self.set_generic_message(
-                            "Error adding track",
-                            &format!(
-                                "Failed to add track {} to playlist {}.",
-                                track_name, playlist.name
-                            ),
-                        );
-                    }
-                    self.playlists
-                        .iter_mut()
-                        .find(|p| p.id == playlist.id)
-                        .map(|p| p.child_count += 1);
 
-                    self.set_generic_message(
-                        "Track added",
-                        &format!(
-                            "Track {} successfully added to playlist {}.",
-                            track_name, playlist.name
-                        ),
-                    );
-                }
-                _ => {
-                    self.close_popup();
-                }
-            },
             _ => {}
         }
         Some(())
@@ -2656,41 +2580,7 @@ impl crate::tui::App {
                     _ => {}
                 }
             }
-            PopupMenu::PlaylistTrackAddToPlaylist { track_name, track_id, playlists } => {
-                if let PopupCommand::AddToPlaylist { playlist_id } = action {
-                    let playlist = playlists.iter().find(|p| p.id == *playlist_id)?;
-                    if self
-                        .client
-                        .as_ref()?
-                        .add_to_playlist(&track_id, playlist_id)
-                        .await
-                        .log_err("add to playlist")
-                        .is_err()
-                    {
-                        self.set_generic_message(
-                            "Error adding track",
-                            &format!(
-                                "Failed to add track {} to playlist {}.",
-                                track_name, playlist.name
-                            ),
-                        );
-                    }
-                    self.playlists
-                        .iter_mut()
-                        .find(|p| p.id == playlist.id)
-                        .map(|p| p.child_count += 1);
 
-                    self.set_generic_message(
-                        "Track added",
-                        &format!(
-                            "Track {} successfully added to playlist {}.",
-                            track_name, playlist.name
-                        ),
-                    );
-                } else {
-                    self.close_popup();
-                }
-            }
             PopupMenu::PlaylistTracksRemove { keys, .. } => match action {
                 PopupCommand::Yes => {
                     self.close_popup();
@@ -3173,6 +3063,10 @@ impl crate::tui::App {
     /// Opens a message with a title and message and an OK button
     ///
     pub fn set_generic_message(&mut self, title: &str, message: &str) {
+        if self.state.active_section != ActiveSection::Popup {
+            self.state.last_section = self.state.active_section;
+            self.state.active_section = ActiveSection::Popup;
+        }
         self.popup.current_menu = Some(PopupMenu::GenericMessage {
             title: title.to_string(),
             message: message.to_string(),
@@ -3180,9 +3074,105 @@ impl crate::tui::App {
         self.popup.selected.select_last(); // move selection to OK options
     }
 
-    /// Clear popup state and ask to render a new default popup
-    /// `create_popup` will then pick this up and render a new popup
-    ///
+    /// Open the playlist picker for the current select-mode selection (Library / Albums panes).
+    pub fn request_selection_add_to_playlist(&mut self) {
+        if self.select.is_empty() {
+            return;
+        }
+        self.popup.global = false;
+        self.state.last_section = self.state.active_section;
+        self.state.active_section = ActiveSection::Popup;
+        self.popup.current_menu = Some(PopupMenu::TracksAddToPlaylist {
+            count: self.select.len(),
+            track_ids: self.select.keys(),
+            playlists: self.playlists.clone(),
+        });
+        self.popup.selected.select_first();
+    }
+
+    async fn handle_add_to_playlist_action(
+        &mut self,
+        action: &PopupCommand,
+        menu: &PopupMenu,
+    ) -> bool {
+        match menu {
+            PopupMenu::TrackAddToPlaylist { track_id, playlists, .. }
+            | PopupMenu::PlaylistTrackAddToPlaylist { track_id, playlists, .. } => {
+                match action {
+                    PopupCommand::AddToPlaylist { playlist_id } => {
+                        let track_ids = vec![track_id.clone()];
+                        self.add_selection_to_playlist(1, &track_ids, playlists, playlist_id)
+                            .await;
+                    }
+                    _ => {
+                        self.close_popup();
+                    }
+                }
+                true
+            }
+            PopupMenu::TracksAddToPlaylist { count, track_ids, playlists } => {
+                match action {
+                    PopupCommand::AddToPlaylist { playlist_id } => {
+                        self.add_selection_to_playlist(*count, track_ids, playlists, playlist_id)
+                            .await;
+                    }
+                    _ => {
+                        self.close_popup();
+                    }
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Add every selected track to the chosen playlist, then leave select mode.
+    async fn add_selection_to_playlist(
+        &mut self,
+        count: usize,
+        track_ids: &[String],
+        playlists: &[Playlist],
+        playlist_id: &String,
+    ) {
+        let Some(playlist) = playlists.iter().find(|p| &p.id == playlist_id) else {
+            return;
+        };
+
+        if self.client.is_none() {
+            return;
+        }
+
+        let mut added = 0usize;
+        for id in track_ids {
+            if let Some(client) = self.client.as_ref() {
+                if client.add_to_playlist(id, playlist_id).await.is_ok() {
+                    added += 1;
+                }
+            }
+        }
+
+        if added > 0 {
+            self.playlists
+                .iter_mut()
+                .find(|p| p.id == playlist.id)
+                .map(|p| p.child_count += added as u64);
+            self.set_generic_message(
+                "Tracks added",
+                &format!(
+                    "Added {} of {} selected track(s) to playlist {}.",
+                    added, count, playlist.name
+                ),
+            );
+        } else {
+            self.set_generic_message(
+                "Error adding tracks",
+                &format!("Failed to add selected tracks to playlist {}.", playlist.name),
+            );
+        }
+
+        self.select.exit();
+    }
+
     pub async fn request_popup(&mut self, global: bool) {
         self.popup.global = global;
 
@@ -3197,6 +3187,7 @@ impl crate::tui::App {
             } else {
                 self.state.last_section = self.state.active_section;
                 self.state.active_section = ActiveSection::Popup;
+                self.popup.current_menu = None;
             }
         }
     }

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -3101,8 +3101,7 @@ impl crate::tui::App {
                 match action {
                     PopupCommand::AddToPlaylist { playlist_id } => {
                         let track_ids = vec![track_id.clone()];
-                        self.add_selection_to_playlist(1, &track_ids, playlists, playlist_id)
-                            .await;
+                        self.add_selection_to_playlist(1, &track_ids, playlists, playlist_id).await;
                     }
                     _ => {
                         self.close_popup();
@@ -3156,6 +3155,16 @@ impl crate::tui::App {
                 .iter_mut()
                 .find(|p| p.id == playlist.id)
                 .map(|p| p.child_count += added as u64);
+            if self.state.current_playlist.id == *playlist_id {
+                self.state.current_playlist.child_count += added as u64;
+            }
+
+            let _ = self
+                .db
+                .cmd_tx
+                .send(Command::Update(UpdateCommand::Playlist { playlist_id: playlist_id.clone() }))
+                .await;
+
             self.set_generic_message(
                 "Tracks added",
                 &format!(

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -3137,20 +3137,19 @@ impl crate::tui::App {
             return;
         };
 
-        if self.client.is_none() {
+        let Some(client) = self.client.as_ref() else {
+            return;
+        };
+
+        if track_ids.is_empty() {
             return;
         }
 
-        let mut added = 0usize;
-        for id in track_ids {
-            if let Some(client) = self.client.as_ref() {
-                if client.add_to_playlist(id, playlist_id).await.is_ok() {
-                    added += 1;
-                }
-            }
-        }
+        let ids = track_ids.join(",");
+        let ok = client.add_to_playlist(&ids, playlist_id).await.is_ok();
 
-        if added > 0 {
+        if ok {
+            let added = track_ids.len();
             self.playlists
                 .iter_mut()
                 .find(|p| p.id == playlist.id)

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -2638,13 +2638,14 @@ impl crate::tui::App {
                         self.copy_lastfm_album_url(&track)?;
                     }
                     PopupCommand::Delete => {
-                        let keys: Vec<String> = if self.playlist_select_mode
-                            && !self.playlist_selected_items.is_empty()
-                        {
-                            self.playlist_selected_items.iter().cloned().collect()
-                        } else {
-                            vec![Self::playlist_track_key(&track)]
-                        };
+                        let keys: Vec<String> =
+                            if self.select.is_active_in(crate::select::SelectPane::PlaylistTracks)
+                                && !self.select.is_empty()
+                            {
+                                self.select.keys()
+                            } else {
+                                vec![Self::playlist_track_key(&track)]
+                            };
                         self.popup.current_menu = Some(PopupMenu::PlaylistTracksRemove {
                             keys,
                             playlist_name: self.state.current_playlist.name.clone(),

--- a/src/select.rs
+++ b/src/select.rs
@@ -12,6 +12,11 @@ use std::collections::HashSet;
 /// Identifies the list pane a select-mode session is bound to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelectPane {
+    /// Artist's discography in the Library tab
+    LibraryTracks,
+    /// Album's tracks in the Albums tab
+    AlbumTracks,
+    /// A playlist's tracks in the Playlists tab
     PlaylistTracks,
 }
 
@@ -33,6 +38,11 @@ impl SelectMode {
 
     pub fn is_active_in(&self, pane: SelectPane) -> bool {
         self.active_pane == Some(pane)
+    }
+
+    /// The pane the session is bound to; `None` while inactive.
+    pub fn pane(&self) -> Option<SelectPane> {
+        self.active_pane
     }
 
     /// Enter select mode in `pane`, seeding the selection with the item under the cursor.

--- a/src/select.rs
+++ b/src/select.rs
@@ -7,7 +7,7 @@ Generic select mode
       seeded with the item under the cursor, and rendering markers via `SelectMode::is_selected`
 -------------------------- */
 
-use std::collections::HashSet;
+use indexmap::IndexSet;
 
 /// Identifies the list pane a select-mode session is bound to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,7 +28,7 @@ pub enum SelectPane {
 pub struct SelectMode {
     /// Pane the session is bound to; `None` while inactive.
     active_pane: Option<SelectPane>,
-    selected: HashSet<String>,
+    selected: IndexSet<String>,
 }
 
 impl SelectMode {
@@ -65,7 +65,7 @@ impl SelectMode {
         if self.active_pane.is_none() || key.is_empty() {
             return;
         }
-        if !self.selected.remove(&key) {
+        if !self.selected.shift_remove(&key) {
             self.selected.insert(key);
         }
     }
@@ -82,8 +82,22 @@ impl SelectMode {
         self.selected.is_empty()
     }
 
-    /// Every marked key, in no particular order.
+    /// Every marked key, in insertion order (deterministic, unlike `HashSet`).
     pub fn keys(&self) -> Vec<String> {
         self.selected.iter().cloned().collect()
+    }
+
+    /// Every marked key sorted to match `canonical_order` (e.g. album order).
+    /// Keys missing from the order keep their insertion order at the end.
+    pub fn ordered_keys(&self, canonical_order: &[String]) -> Vec<String> {
+        use std::collections::HashMap;
+        let position: HashMap<&str, usize> = canonical_order
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (k.as_str(), i))
+            .collect();
+        let mut keys = self.keys();
+        keys.sort_by_key(|k| position.get(k.as_str()).copied().unwrap_or(usize::MAX));
+        keys
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -91,11 +91,8 @@ impl SelectMode {
     /// Keys missing from the order keep their insertion order at the end.
     pub fn ordered_keys(&self, canonical_order: &[String]) -> Vec<String> {
         use std::collections::HashMap;
-        let position: HashMap<&str, usize> = canonical_order
-            .iter()
-            .enumerate()
-            .map(|(i, k)| (k.as_str(), i))
-            .collect();
+        let position: HashMap<&str, usize> =
+            canonical_order.iter().enumerate().map(|(i, k)| (k.as_str(), i)).collect();
         let mut keys = self.keys();
         keys.sort_by_key(|k| position.get(k.as_str()).copied().unwrap_or(usize::MAX));
         keys

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,0 +1,79 @@
+/* --------------------------
+Generic select mode
+    - Lets a list pane mark several items, then act on them all at once
+    - What a key means is up to the pane (playlist entry id, media id, ...); it only has to
+      be stable for the lifetime of the session
+    - A pane opts in by picking a `SelectPane` variant, entering with `SelectMode::enter`
+      seeded with the item under the cursor, and rendering markers via `SelectMode::is_selected`
+-------------------------- */
+
+use std::collections::HashSet;
+
+/// Identifies the list pane a select-mode session is bound to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectPane {
+    PlaylistTracks,
+}
+
+/// State of a select-mode session.
+///
+/// What a key means is up to the pane (playlist entry id, media id, ...); it only has to be
+/// stable for the lifetime of the session.
+#[derive(Debug, Default)]
+pub struct SelectMode {
+    /// Pane the session is bound to; `None` while inactive.
+    active_pane: Option<SelectPane>,
+    selected: HashSet<String>,
+}
+
+impl SelectMode {
+    pub fn is_active(&self) -> bool {
+        self.active_pane.is_some()
+    }
+
+    pub fn is_active_in(&self, pane: SelectPane) -> bool {
+        self.active_pane == Some(pane)
+    }
+
+    /// Enter select mode in `pane`, seeding the selection with the item under the cursor.
+    pub fn enter(&mut self, pane: SelectPane, cursor_key: Option<String>) {
+        self.active_pane = Some(pane);
+        self.selected.clear();
+        if let Some(key) = cursor_key.filter(|k| !k.is_empty()) {
+            self.selected.insert(key);
+        }
+    }
+
+    /// Leave select mode, forgetting every marked item.
+    pub fn exit(&mut self) {
+        self.active_pane = None;
+        self.selected.clear();
+    }
+
+    /// Mark `key`, or unmark it if it was already marked. No-op while inactive.
+    pub fn toggle(&mut self, key: String) {
+        if self.active_pane.is_none() || key.is_empty() {
+            return;
+        }
+        if !self.selected.remove(&key) {
+            self.selected.insert(key);
+        }
+    }
+
+    pub fn is_selected(&self, key: &str) -> bool {
+        self.selected.contains(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.selected.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.selected.is_empty()
+    }
+
+    /// Every marked key, in no particular order.
+    pub fn keys(&self) -> Vec<String> {
+        self.selected.iter().cloned().collect()
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,12 +1,14 @@
 //! Unit tests for logic that's awkward to exercise through the full App/terminal stack, grouped
 //! by the subsystem they cover. discography_view and play_range test the row/model mapping and
-//! play-range resolution of album folding; popup tests the queue track popup. All of it is pure
-//! functions or plain state mutation, so none of it needs a terminal, server or mpv handle.
+//! play-range resolution of album folding; popup tests the queue track popup; select tests the
+//! generic select-mode state machine. All of it is pure functions or plain state mutation, so
+//! none of it needs a terminal, server or mpv handle.
 
 mod album_column;
 mod discography_view;
 mod play_range;
 mod popup;
+mod select;
 
 use crate::client::DiscographySong;
 

--- a/src/tests/popup.rs
+++ b/src/tests/popup.rs
@@ -73,3 +73,22 @@ fn playlist_removal_popup_counts_every_marked_track() {
     let options = menu.options("favorite");
     assert!(options[0].name().contains('3'), "{}", options[0].name());
 }
+
+#[test]
+fn set_generic_message_activates_popup_section() {
+    let mut state = State::new();
+    state.active_section = ActiveSection::Tracks;
+    let mut popup = PopupState::default();
+
+    // Simulating helper call with state
+    state.last_section = state.active_section;
+    state.active_section = ActiveSection::Popup;
+    popup.current_menu = Some(PopupMenu::GenericMessage {
+        title: "Tracks removed".to_string(),
+        message: "Removed 1 track(s)".to_string(),
+    });
+
+    assert_eq!(state.active_section, ActiveSection::Popup);
+    assert_eq!(state.last_section, ActiveSection::Tracks);
+    assert!(matches!(popup.current_menu, Some(PopupMenu::GenericMessage { .. })));
+}

--- a/src/tests/select.rs
+++ b/src/tests/select.rs
@@ -1,5 +1,5 @@
 //! Tests for the non-obvious decisions of the generic select-mode state machine (src/select.rs).
-//! The rest is a thin HashSet wrapper not worth pinning down.
+//! The rest is a thin IndexSet wrapper not worth pinning down.
 
 use crate::select::{SelectMode, SelectPane};
 

--- a/src/tests/select.rs
+++ b/src/tests/select.rs
@@ -34,3 +34,12 @@ fn toggle_ignores_empty_keys() {
     select.toggle(String::new());
     assert!(select.is_empty());
 }
+
+#[test]
+fn entering_another_pane_steals_the_session() {
+    let mut select = SelectMode::default();
+    select.enter(SelectPane::PlaylistTracks, None);
+    select.enter(SelectPane::LibraryTracks, Some("x".to_string()));
+    assert_eq!(select.pane(), Some(SelectPane::LibraryTracks));
+    assert!(!select.is_active_in(SelectPane::PlaylistTracks));
+}

--- a/src/tests/select.rs
+++ b/src/tests/select.rs
@@ -1,0 +1,36 @@
+//! Tests for the non-obvious decisions of the generic select-mode state machine (src/select.rs).
+//! The rest is a thin HashSet wrapper not worth pinning down.
+
+use crate::select::{SelectMode, SelectPane};
+
+#[test]
+fn enter_ignores_an_empty_seed() {
+    let mut select = SelectMode::default();
+    select.enter(SelectPane::PlaylistTracks, Some(String::new()));
+    assert!(select.is_active());
+    assert!(select.is_empty());
+}
+
+#[test]
+fn entering_a_new_session_drops_the_previous_selection() {
+    let mut select = SelectMode::default();
+    select.enter(SelectPane::PlaylistTracks, Some("old".to_string()));
+    select.enter(SelectPane::PlaylistTracks, None);
+    assert!(!select.is_selected("old"));
+    assert!(select.is_empty());
+}
+
+#[test]
+fn toggle_is_a_no_op_while_inactive() {
+    let mut select = SelectMode::default();
+    select.toggle("a".to_string());
+    assert!(select.is_empty());
+}
+
+#[test]
+fn toggle_ignores_empty_keys() {
+    let mut select = SelectMode::default();
+    select.enter(SelectPane::PlaylistTracks, None);
+    select.toggle(String::new());
+    assert!(select.is_empty());
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -30,6 +30,7 @@ use crate::helpers::{
 use crate::keyboard::{try_load_keymap, ActiveSection, ActiveTab, Selectable};
 use crate::mpv::MpvHandle;
 use crate::popup::PopupState;
+use crate::select::SelectMode;
 use crate::themes::dialoguer::DialogTheme;
 use crate::themes::theme::Theme;
 use crate::{helpers, sort};
@@ -310,10 +311,8 @@ pub struct App {
     pub playlist_editing: bool, // this means the playlist has been changed by the user (such as changing track order). Send after ops done for obvious reasons
     pub playlist_edit_item_id: Option<String>,
     pub playlist_edit_origin_index: Option<usize>,
-    /// Select mode in the playlist tracks pane: mark several tracks, then remove them at once.
-    pub playlist_select_mode: bool,
-    /// Tracks currently marked in playlist select mode (playlist entry id, or media id as fallback).
-    pub playlist_selected_items: HashSet<String>,
+    /// Select-mode session: mark several items in a list pane, then act on them at once.
+    pub select: SelectMode,
 
     // dynamic frame bound heights for page up/down
     pub left_list_height: usize,
@@ -657,8 +656,7 @@ impl App {
             playlist_editing: false,
             playlist_edit_item_id: None,
             playlist_edit_origin_index: None,
-            playlist_select_mode: false,
-            playlist_selected_items: HashSet::new(),
+            select: SelectMode::default(),
 
             // these get overwritten in the first run loop
             left_list_height: 0,


### PR DESCRIPTION
I'm currently working on selecting multiple songs at once and adding them to the playlist. I'm leaving this as a draft for now because I first had to do some refactoring, and I wanted to leave it here to show that I'm actively working on it.

I'll keep pushing the commits little by little, and I'll mark the PR as ready once everything is finished.

I'm keeping it as a draft for now because I started working on this this morning and noticed that some recent changes required me to adapt part of the refactor. So, while I'm working on it, it would be good to keep the refactor in mind if any further changes are made, so that everything can be merged cleanly afterwards.

I'll continue working on it and update the PR as I go.