### PR TITLE
fix: sync track play count from server after playback stops

### DIFF
--- a/src/database/database.rs
+++ b/src/database/database.rs
@@ -366,28 +366,29 @@ pub async fn t_database<'a>(
                     Command::Jellyfin(jellyfin_cmd) => {
                         match jellyfin_cmd {
                             JellyfinCommand::Stopped { id, position_ticks } => {
-                                let _ = client.stopped(id.clone(), position_ticks).await.log_err("send stopped report");
-                                if let Some(song_id) = id {
-                                    let client = client.clone();
-                                    let pool = Arc::clone(&pool);
-                                    let tx = tx.clone();
-                                    tokio::spawn(async move {
-                                        tokio::time::sleep(Duration::from_millis(500)).await;
-                                        if let Ok(tracks) = client.tracks_by_ids(&[song_id.clone()]).await {
-                                            if let Some(track) = tracks.into_iter().next() {
-                                                if let Ok(json_str) = serde_json::to_string(&track) {
-                                                    let _ = sqlx::query(
-                                                        "UPDATE tracks SET track = ?, last_played = CURRENT_TIMESTAMP WHERE id = ?"
-                                                    )
-                                                    .bind(&json_str)
-                                                    .bind(&song_id)
-                                                    .execute(&*pool)
-                                                    .await;
-                                                    let _ = tx.send(Status::TrackUserDataUpdated { song_id, user_data: track.user_data }).await;
+                                match client.stopped(id.clone(), position_ticks).await.log_err("send stopped report") {
+                                    Ok(()) => if let Some(song_id) = id {
+                                        let client = client.clone();
+                                        let pool = Arc::clone(&pool);
+                                        let tx = tx.clone();
+                                        tokio::spawn(async move {
+                                            if let Ok(tracks) = client.tracks_by_ids(&[song_id.clone()]).await {
+                                                if let Some(track) = tracks.into_iter().next() {
+                                                    if let Ok(user_data_json) = serde_json::to_string(&track.user_data) {
+                                                        let _ = sqlx::query(
+                                                            "UPDATE tracks SET track = json_set(track, '$.UserData', json(?)), last_played = CURRENT_TIMESTAMP WHERE id = ?"
+                                                        )
+                                                        .bind(&user_data_json)
+                                                        .bind(&song_id)
+                                                        .execute(&*pool)
+                                                        .await;
+                                                        let _ = tx.send(Status::TrackUserDataUpdated { song_id, user_data: track.user_data }).await;
+                                                    }
                                                 }
                                             }
-                                        }
-                                    });
+                                        });
+                                    },
+                                    Err(_) => {} // nothing we can do if the stopped report failed
                                 }
                             }
                             JellyfinCommand::Playing { progress_report } => {

--- a/src/database/database.rs
+++ b/src/database/database.rs
@@ -4,7 +4,7 @@ use super::extension::{
 use crate::client::{NetworkQuality, ProgressReport};
 use crate::helpers::LogErr;
 use crate::{
-    client::{Artist, Client, DiscographySong, Lyric},
+    client::{Artist, Client, DiscographySong, DiscographySongUserData, Lyric},
     database::extension::{
         query_download_tracks, remove_track_download, remove_tracks_downloads, DownloadStatus,
     },
@@ -62,6 +62,7 @@ pub enum Status {
     TrackDownloading { track: DiscographySong },
     TrackDownloaded { id: String },
     TrackDeleted { id: String },
+    TrackUserDataUpdated { song_id: String, user_data: DiscographySongUserData },
     CoverArtDownloaded { item_id: Option<String> },
 
     ArtistsUpdated,
@@ -365,7 +366,29 @@ pub async fn t_database<'a>(
                     Command::Jellyfin(jellyfin_cmd) => {
                         match jellyfin_cmd {
                             JellyfinCommand::Stopped { id, position_ticks } => {
-                                let _ = client.stopped(id, position_ticks).await.log_err("send stopped report");
+                                let _ = client.stopped(id.clone(), position_ticks).await.log_err("send stopped report");
+                                if let Some(song_id) = id {
+                                    let client = client.clone();
+                                    let pool = Arc::clone(&pool);
+                                    let tx = tx.clone();
+                                    tokio::spawn(async move {
+                                        tokio::time::sleep(Duration::from_millis(500)).await;
+                                        if let Ok(tracks) = client.tracks_by_ids(&[song_id.clone()]).await {
+                                            if let Some(track) = tracks.into_iter().next() {
+                                                if let Ok(json_str) = serde_json::to_string(&track) {
+                                                    let _ = sqlx::query(
+                                                        "UPDATE tracks SET track = ?, last_played = CURRENT_TIMESTAMP WHERE id = ?"
+                                                    )
+                                                    .bind(&json_str)
+                                                    .bind(&song_id)
+                                                    .execute(&*pool)
+                                                    .await;
+                                                    let _ = tx.send(Status::TrackUserDataUpdated { song_id, user_data: track.user_data }).await;
+                                                }
+                                            }
+                                        }
+                                    });
+                                }
                             }
                             JellyfinCommand::Playing { progress_report } => {
                                 let _ = client.playing(&progress_report).await.log_err("send playing report");

--- a/src/database/extension.rs
+++ b/src/database/extension.rs
@@ -346,6 +346,23 @@ impl tui::App {
                 self.db_updating = false;
                 self.update_progress = None;
             }
+            Status::TrackUserDataUpdated { song_id, user_data } => {
+                for track in &mut self.tracks {
+                    if track.id == song_id {
+                        track.user_data = user_data.clone();
+                    }
+                }
+                for track in &mut self.album_tracks {
+                    if track.id == song_id {
+                        track.user_data = user_data.clone();
+                    }
+                }
+                for track in &mut self.playlist_tracks {
+                    if track.id == song_id {
+                        track.user_data = user_data.clone();
+                    }
+                }
+            }
             Status::Error { error } => {
                 self.state.last_section = self.state.active_section;
                 self.state.active_section = ActiveSection::Popup;


### PR DESCRIPTION
Updates track user data, such as `play_count` and `played` status, in real time when a track finishes playing by fetching the latest metadata from the Jellyfin server.

**Problem**

When a track finishes playing, Jellyfin-TUI sends a `Stopped` report (`POST /Sessions/Playing/Stopped`) to the Jellyfin server.

However, the `Stopped` endpoint returns an empty HTTP 204 response, so Jellyfin-TUI previously had no updated track data to apply locally.

Because the client did not fetch the track metadata again after playback stopped, the **Plays** column stayed unchanged until the library or playlist was manually reloaded.

**Solution**

When a track finishes playing, we now fetch its updated metadata from Jellyfin in the background:

1. **Fetch updated metadata after playback stops**

   In `src/database/database.rs`, when `JellyfinCommand::Stopped` is processed, a background task waits 500 ms to give Jellyfin time to persist the playback data and then fetches the track again using `client.tracks_by_ids(&[song_id])`.

2. **Update the local database and state**

   The updated track JSON is saved to the SQLite `tracks` table, and a `Status::TrackUserDataUpdated { song_id, user_data }` event is sent to the UI thread.

3. **Refresh the UI in real time**

   In `src/database/extension.rs`, the corresponding track is updated in the in-memory `tracks`, `album_tracks`, and `playlist_tracks` collections.

   This makes the **Plays** column update immediately after a track finishes, without needing to switch tabs or reload the library or playlist.
