### PR TITLE
nix(chore): update inputs, set rust-src path for rust analyzer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776350315,
-        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
+        "lastModified": 1788765185,
+        "narHash": "sha256-pp8lb5CrKjmscZbTK34HuCaq18zDU4Q6zlaD5dS+Hi4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
+        "rev": "ca7f624be3935a5bc46d2c240515491ab8675503",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
               ./Cargo.toml
               ./Cargo.lock
               ./src
+              ./crates
             ];
           };
 
@@ -85,7 +86,9 @@
               inherit system;
               overlays = [ (import rust-overlay) ];
             };
-            toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+            toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+              extensions = [ "rust-src" ];
+            };
           in
           f { inherit pkgs toolchain; }
         );
@@ -136,6 +139,7 @@
               OPENSSL_DIR = "${pkgs.openssl.dev}";
               OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
               OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include";
+              RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
             };
           };
         }


### PR DESCRIPTION
Updated the flake.lock using `nix flake update`
Fix: missing `crates` directory in src fitler.
devShell: exposed rust-src path for rust analyzer.